### PR TITLE
Reduced schema for Solr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>uk.ac.ebi.pride</groupId>
     <artifactId>protein-identification-index-search</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</version>
     <name>protein-identification-index-search</name>
     <url>https://github.com/PRIDE-Archive/protein-identification-index-service</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,14 @@
     -->
 
     <properties>
-        <protein.catalog.index.search.version>1.0.0</protein.catalog.index.search.version>
-        <archive.repo.version>0.1.19</archive.repo.version>
+        <protein.catalog.index.search.version>1.0.1-SNAPSHOT</protein.catalog.index.search.version>
+        <archive.repo.version>0.1.20-SNAPSHOT</archive.repo.version>
         <archive.data.provider.api.version>2.0.9</archive.data.provider.api.version>
         <archive.utils.version>0.1.21</archive.utils.version>
         <accession.resolver.version>1.0.1</accession.resolver.version>
         <index.utils.version>1.0.0</index.utils.version>
     </properties>
-
+t
     <build>
         <resources>
             <!-- regular resources -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>uk.ac.ebi.pride</groupId>
     <artifactId>protein-identification-index-search</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.1-REDUCED_SCHEMA-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>protein-identification-index-search</name>
     <url>https://github.com/PRIDE-Archive/protein-identification-index-service</url>
 
@@ -27,8 +27,8 @@
     -->
 
     <properties>
-        <protein.catalog.index.search.version>1.0.1-SNAPSHOT</protein.catalog.index.search.version>
-        <archive.repo.version>0.1.20-SNAPSHOT</archive.repo.version>
+        <protein.catalog.index.search.version>1.0.1</protein.catalog.index.search.version>
+        <archive.repo.version>1.0.0</archive.repo.version>
         <archive.data.provider.api.version>2.0.9</archive.data.provider.api.version>
         <archive.utils.version>0.1.21</archive.utils.version>
         <accession.resolver.version>1.0.1</accession.resolver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <accession.resolver.version>1.0.1</accession.resolver.version>
         <index.utils.version>1.0.0</index.utils.version>
     </properties>
-t
+
     <build>
         <resources>
             <!-- regular resources -->

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationsIndexer.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationsIndexer.java
@@ -22,166 +22,119 @@ import java.util.TreeSet;
  */
 public class ProjectProteinIdentificationsIndexer {
 
-    private static Logger logger = LoggerFactory.getLogger(ProjectProteinIdentificationsIndexer.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ProjectProteinIdentificationsIndexer.class.getName());
 
-    private ProteinIdentificationSearchService proteinIdentificationSearchService;
-    private ProteinIdentificationIndexService proteinIdentificationIndexService;
+  private ProteinIdentificationSearchService proteinIdentificationSearchService;
+  private ProteinIdentificationIndexService proteinIdentificationIndexService;
 
-    private ProteinCatalogSearchService proteinCatalogSearchService;
-    private ProteinCatalogIndexService proteinCatalogIndexService;
-    private ProteinDetailsIndexer proteinCatalogDetailsIndexer;
+  private ProteinCatalogSearchService proteinCatalogSearchService;
+  private ProteinCatalogIndexService proteinCatalogIndexService;
+  private ProteinDetailsIndexer proteinCatalogDetailsIndexer;
 
 
-    public ProjectProteinIdentificationsIndexer(ProteinIdentificationSearchService proteinIdentificationSearchService,
-                                                ProteinIdentificationIndexService proteinIdentificationIndexService,
-                                                ProteinCatalogSearchService proteinCatalogSearchService,
-                                                ProteinCatalogIndexService proteinCatalogIndexService,
-                                                ProteinDetailsIndexer proteinCatalogDetailsIndexer) {
-        this.proteinIdentificationSearchService = proteinIdentificationSearchService;
-        this.proteinIdentificationIndexService = proteinIdentificationIndexService;
-        this.proteinCatalogSearchService = proteinCatalogSearchService;
-        this.proteinCatalogIndexService = proteinCatalogIndexService;
-        this.proteinCatalogDetailsIndexer = proteinCatalogDetailsIndexer;
-    }
+  public ProjectProteinIdentificationsIndexer(ProteinIdentificationSearchService proteinIdentificationSearchService,
+                                              ProteinIdentificationIndexService proteinIdentificationIndexService,
+                                              ProteinCatalogSearchService proteinCatalogSearchService,
+                                              ProteinCatalogIndexService proteinCatalogIndexService,
+                                              ProteinDetailsIndexer proteinCatalogDetailsIndexer) {
+    this.proteinIdentificationSearchService = proteinIdentificationSearchService;
+    this.proteinIdentificationIndexService = proteinIdentificationIndexService;
+    this.proteinCatalogSearchService = proteinCatalogSearchService;
+    this.proteinCatalogIndexService = proteinCatalogIndexService;
+    this.proteinCatalogDetailsIndexer = proteinCatalogDetailsIndexer;
+  }
 
-    @Deprecated
-    public void indexAllProjectIdentificationsForProjectAndAssay(String projectAccession, String assayAccession, MZTabFile mzTabFile){
-        this.indexAllProteinIdentificationsForProjectAndAssay(projectAccession, assayAccession, mzTabFile);
-    }
+  public void indexAllProteinIdentificationsForProjectAndAssay(String projectAccession, String assayAccession, MZTabFile mzTabFile){
+    try {  // build Protein Identifications from mzTabFile
+      if (mzTabFile != null) {
+        List<ProteinIdentification> proteinsFromFile = ProteinIdentificationMzTabBuilder.readProteinIdentificationsFromMzTabFile(projectAccession, assayAccession, mzTabFile);
+        logger.debug("Found " + proteinsFromFile.size() + " Protein Identifications "
+            + " for PROJECT:" + projectAccession
+            + " and ASSAY:" + assayAccession);
 
-    public void indexAllProteinIdentificationsForProjectAndAssay(String projectAccession, String assayAccession, MZTabFile mzTabFile){
-
-        // build Protein Identifications from mzTabFile
-        try {
-            if (mzTabFile != null) {
-                List<ProteinIdentification> proteinsFromFile = ProteinIdentificationMzTabBuilder.readProteinIdentificationsFromMzTabFile(projectAccession, assayAccession, mzTabFile);
-
-                logger.debug("Found " + proteinsFromFile.size() + " Protein Identifications "
-                        + " for PROJECT:" + projectAccession
-                        + " and ASSAY:" + assayAccession);
-
-                if (proteinsFromFile!=null && proteinsFromFile.size()>0) {
-                    // add synonyms, details, etc
-                    addCatalogInfoToProteinIdentifications(proteinsFromFile);
-                    // save
-                    proteinIdentificationIndexService.save(proteinsFromFile);
-
-                    logger.debug("COMMITTED " + proteinsFromFile.size() +
-                            " Protein Identifications from PROJECT:" + projectAccession +
-                            " ASSAY:" + assayAccession);
-                }
-            } else {
-                logger.error("An empty mzTab file has been passed to the indexing method - no indexing took place");
-            }
-        } catch (Exception e) {
-            logger.error("Cannot index Protein Identifications from PROJECT:" + projectAccession + " and ASSAY:" + assayAccession );
-            logger.error("Reason: ");
-            e.printStackTrace();
+        if (proteinsFromFile.size()>0) {
+          addCatalogInfoToProteinIdentifications(proteinsFromFile);
+          proteinIdentificationIndexService.save(proteinsFromFile);
+          logger.debug("COMMITTED " + proteinsFromFile.size() +
+              " Protein Identifications from PROJECT:" + projectAccession +
+              " ASSAY:" + assayAccession);
         }
-
+      } else {
+        logger.error("An empty mzTab file has been passed to the indexing method - no indexing took place");
+      }
+    } catch (Exception e) {
+      logger.error("Cannot index Protein Identifications from PROJECT:" + projectAccession + " and ASSAY:" + assayAccession );
+      logger.error("Reason: ");
+      e.printStackTrace();
     }
+  }
 
-    /**
-     * Deletes all protein identifications for a given project accession
-     *
-     * @param projectAccession The accession that identifies the PRIDE Archive project
-     */
-    public void deleteAllProteinIdentificationsForProject(String projectAccession) {
-        // search by project accession
-        List<ProteinIdentification> proteinIdentifications = this.proteinIdentificationSearchService.findByProjectAccession(projectAccession);
-        this.proteinIdentificationIndexService.delete(proteinIdentifications);
+  /**
+   * Deletes all protein identifications for a given project accession
+   *
+   * @param projectAccession The accession that identifies the PRIDE Archive project
+   */
+  public void deleteAllProteinIdentificationsForProject(String projectAccession) {
+    this.proteinIdentificationIndexService.delete(this.proteinIdentificationSearchService.findByProjectAccession(projectAccession));
+  }
+
+  /**
+   * Use the protein Catalog to retrieve synonym information, protein details, etc.
+   *
+   * @param proteinIdentifications The list to be enriched with information from the Catalog
+   */
+  private void addCatalogInfoToProteinIdentifications(List<ProteinIdentification> proteinIdentifications) {
+    List<ProteinIdentified> proteinsToCatalog = new LinkedList<>();
+    for (ProteinIdentification proteinIdentification: proteinIdentifications) {
+      List<ProteinIdentified> proteinsFromCatalog = proteinCatalogSearchService.findByAccession(proteinIdentification.getAccession());
+      if (proteinsFromCatalog == null || proteinsFromCatalog.size() == 0) {
+        logger.debug("Protein " + proteinIdentification.getAccession() + " not in the Catalog - adding...");
+        proteinsToCatalog.addAll(getAsCatalogProtein(proteinIdentification));
+      }
     }
-
-    /**
-     * Use the protein Catalog to retrieve synonym information, protein details, etc.
-     *
-     * @param proteinIdentifications The list to be enriched with information from the Catalog
-     */
-    private void addCatalogInfoToProteinIdentifications(List<ProteinIdentification> proteinIdentifications) {
-        List<ProteinIdentified> proteinsToCatalog = new LinkedList<ProteinIdentified>();
-
-        // a first round, will identify new proteins for the catalog
-        // we do it this way, since we want to save to the catalog in batches (to improve performance)
-        // if we process identifications and catalog at the same time, we have to save to the catalog once by one
-        for (ProteinIdentification proteinIdentification: proteinIdentifications) {
-            List<ProteinIdentified> proteinsFromCatalog = proteinCatalogSearchService.findByAccession(proteinIdentification.getAccession());
-            if (proteinsFromCatalog == null || proteinsFromCatalog.size() == 0) {
-                logger.debug("Protein " + proteinIdentification.getAccession() + " not in the Catalog - adding...");
-                proteinsToCatalog.addAll(getAsCatalogProtein(proteinIdentification));
-            }
-        }
-
-        // if it happened that there were new proteins to the catalog, we need to save them (in batch)
-        if (proteinsToCatalog.size()>0) {
-            saveProteinsToCatalog(proteinsToCatalog);
-        }
-
-        // now we are save to assume that the catalog contains all the identified proteins
-        for (ProteinIdentification proteinIdentification: proteinIdentifications) {
-            proteinIdentification.setOtherMappings(new TreeSet<String>());
-            proteinIdentification.setDescription(new LinkedList<String>());
-            List<ProteinIdentified> proteinsFromCatalog = proteinCatalogSearchService.findByAccession(proteinIdentification.getAccession());
-            if (proteinsFromCatalog != null && proteinsFromCatalog.size() > 0) {
-                logger.debug("Protein " + proteinIdentification.getAccession() + " already in the Catalog - getting details...");
-                for (ProteinIdentified proteinFromCatalog : proteinsFromCatalog) {
-                    updateProteinIdentification(proteinIdentification, proteinFromCatalog);
-                }
-            } else { // if not present, there were errors...
-                logger.error("Protein " + proteinIdentification.getId() + " not in the catalog - It should be saved by now...");
-            }
-        }
-
+    // if it happened that there were new proteins to the catalog, we need to save them (in batch)
+    if (proteinsToCatalog.size()>0) {
+      saveProteinsToCatalog(proteinsToCatalog);
     }
+  }
 
-    /**
-     * This is a convenience method to convert from Protein Identification to Catalog model
-     *
-     * @param proteinIdentification The protein identification
-     * @return A list of protein Catalog proteins
-     */
-    private List<ProteinIdentified> getAsCatalogProtein(ProteinIdentification proteinIdentification) {
-        List<ProteinIdentification> pis = new LinkedList<ProteinIdentification>();
-        pis.add(proteinIdentification);
-        return getAsCatalogProtein(pis);
+  /**
+   * This is a convenience method to convert from Protein Identification to Catalog model
+   *
+   * @param proteinIdentification The protein identification
+   * @return A list of protein Catalog proteins
+   */
+  private List<ProteinIdentified> getAsCatalogProtein(ProteinIdentification proteinIdentification) {
+    List<ProteinIdentification> pis = new LinkedList<>();
+    pis.add(proteinIdentification);
+    return getAsCatalogProtein(pis);
+  }
+
+  /**
+   * This is a convenience method to convert from Protein Identification to Catalog model
+   *
+   * @param proteinIdentifications The list of protein identifications
+   * @return A list of protein Catalog proteins
+   */
+  private List<ProteinIdentified> getAsCatalogProtein(List<ProteinIdentification> proteinIdentifications) {
+    List<ProteinIdentified> result = new LinkedList<>();
+    if (proteinIdentifications != null) {
+      for (ProteinIdentification proteinIdentification: proteinIdentifications) {
+        ProteinIdentified newPI = new ProteinIdentified();
+        newPI.setAccession(proteinIdentification.getAccession());
+        result.add(newPI);
+      }
     }
+    return result;
+  }
 
-    /**
-     * This is a convenience method to convert from Protein Identification to Catalog model
-     *
-     * @param proteinIdentifications The list of protein identifications
-     * @return A list of protein Catalog proteins
-     */
-    private List<ProteinIdentified> getAsCatalogProtein(List<ProteinIdentification> proteinIdentifications) {
-        if (proteinIdentifications != null) {
-            List<ProteinIdentified> res = new LinkedList<ProteinIdentified>();
-            for (ProteinIdentification proteinIdentification: proteinIdentifications) {
-                ProteinIdentified newPI = new ProteinIdentified();
-                newPI.setAccession(proteinIdentification.getAccession());
-                res.add(newPI);
-            }
-            return res;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Save proteins into the catalog, including adding synonyms and details
-     * @param proteinsToCatalog
-     */
-    private void saveProteinsToCatalog(List<ProteinIdentified> proteinsToCatalog) {
-        this.proteinCatalogIndexService.save(proteinsToCatalog);
-        this.proteinCatalogDetailsIndexer.addMappingsToProteins(proteinsToCatalog);
-        this.proteinCatalogDetailsIndexer.addDetailsToProteins(proteinsToCatalog);
-    }
-
-    private void updateProteinIdentification(ProteinIdentification proteinIdentification, ProteinIdentified proteinFromCatalog) {
-        if (proteinFromCatalog.getUniprotMapping()!=null) proteinIdentification.setUniprotMapping(proteinFromCatalog.getUniprotMapping());
-        if (proteinFromCatalog.getEnsemblMapping()!=null) proteinIdentification.setEnsemblMapping(proteinFromCatalog.getEnsemblMapping());
-        if (proteinFromCatalog.getOtherMappings() != null) proteinIdentification.getOtherMappings().addAll(proteinFromCatalog.getOtherMappings());
-        if (proteinFromCatalog.getDescription() != null) proteinIdentification.getDescription().addAll(proteinFromCatalog.getDescription());
-        proteinIdentification.setInferredSequence(proteinFromCatalog.getInferredSequence());
-    }
-
-
+  /**
+   * Save proteins into the catalog, including adding synonyms and details
+   * @param proteinsToCatalog
+   */
+  private void saveProteinsToCatalog(List<ProteinIdentified> proteinsToCatalog) {
+    this.proteinCatalogIndexService.save(proteinsToCatalog);
+    this.proteinCatalogDetailsIndexer.addMappingsToProteins(proteinsToCatalog);
+    this.proteinCatalogDetailsIndexer.addDetailsToProteins(proteinsToCatalog);
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
@@ -21,6 +21,7 @@ public class ProteinIdentification implements IdentificationProvider {
 
   @Field(ProteinIdentificationFields.MOD_NAMES)
   private List<String> modificationNames;
+
   @Field(ProteinIdentificationFields.PROJECT_ACCESSION)
   private String projectAccession;
 

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
@@ -2,10 +2,7 @@ package uk.ac.ebi.pride.proteinidentificationindex.search.model;
 
 import org.apache.solr.client.solrj.beans.Field;
 import uk.ac.ebi.pride.archive.dataprovider.identification.ModificationProvider;
-import uk.ac.ebi.pride.archive.dataprovider.identification.ProteinDetailProvider;
-import uk.ac.ebi.pride.archive.dataprovider.identification.ProteinIdentificationProvider;
 import uk.ac.ebi.pride.indexutils.helpers.ModificationHelper;
-import uk.ac.ebi.pride.proteincatalogindex.search.util.ProteinDetailUtils;
 
 import java.util.*;
 
@@ -13,237 +10,73 @@ import java.util.*;
  * @author Jose A. Dianes
  * @version $Id$
  */
-public class ProteinIdentification implements ProteinIdentificationProvider, ProteinDetailProvider {
+public class ProteinIdentification {
 
-    @Field(ProteinIdentificationFields.ID)
-    private String id;
+  @Field(ProteinIdentificationFields.ID)
+  private String id;
 
-    @Field(ProteinIdentificationFields.SUBMITTED_ACCESSION)
-    private String submittedAccession;
+  @Field(ProteinIdentificationFields.ACCESSION)
+  private String accession;
 
-    @Field(ProteinIdentificationFields.ACCESSION)
-    private String accession;
+  @Field(ProteinIdentificationFields.MOD_NAMES)
+  private List<String> modificationNames;
+  @Field(ProteinIdentificationFields.PROJECT_ACCESSION)
+  private String projectAccession;
 
-    @Field(ProteinIdentificationFields.UNIPROT_MAPPING)
-    private String uniprotMapping;
+  @Field(ProteinIdentificationFields.ASSAY_ACCESSION)
+  private String assayAccession;
 
-    @Field(ProteinIdentificationFields.ENSEMBL_MAPPING)
-    private String ensemblMapping;
+  public String getId() {
+    return id;
+  }
 
-    @Field(ProteinIdentificationFields.OTHER_MAPPINGS)
-    private Set<String> otherMappings;
+  public void setId(String id) {
+    this.id = id;
+  }
 
-    @Field(ProteinIdentificationFields.SUBMITTED_SEQUENCE)
-    private String submittedSequence;
+  public String getAccession() {
+    return accession;
+  }
 
-    @Field(ProteinIdentificationFields.INFERRED_SEQUENCE)
-    private String inferredSequence;
+  public void setAccession(String accession) {
+    this.accession = accession;
+  }
 
-    @Field(ProteinIdentificationFields.DESCRIPTION)
-    private List<String> description;
+  public String getProjectAccession() {
+    return projectAccession;
+  }
 
-    @Field(ProteinIdentificationFields.AMBIGUITY_GROUP)
-    private List<String> ambiguityGroupSubmittedAccessions;
+  public void setProjectAccession(String projectAccession) {
+    this.projectAccession = projectAccession;
+  }
 
-    @Field(ProteinIdentificationFields.MODIFICATIONS)
-    private List<String> modificationsAsString;
+  public String getAssayAccession() {
+    return assayAccession;
+  }
 
-    @Field(ProteinIdentificationFields.MOD_NAMES)
-    private List<String> modificationNames;
+  public void setAssayAccession(String assayAccession) {
+    this.assayAccession = assayAccession;
+  }
 
-    @Field(ProteinIdentificationFields.MOD_ACCESSIONS)
-    private List<String> modificationAccessions;
+  public Iterable<String> getModificationNames() {
+    return this.modificationNames;
+  }
 
-    @Field(ProteinIdentificationFields.PROJECT_ACCESSION)
-    private String projectAccession;
-
-    @Field(ProteinIdentificationFields.ASSAY_ACCESSION)
-    private String assayAccession;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getSubmittedAccession() {
-        return submittedAccession;
-    }
-
-    public void setSubmittedAccession(String submittedAccession) {
-        this.submittedAccession = submittedAccession;
-    }
-
-    public String getAccession() {
-        return accession;
-    }
-
-    public void setAccession(String accession) {
-        this.accession = accession;
-    }
-
-    @Override
-    public String getName() {
-        return ProteinDetailUtils.getNameFromDescription(description);
-    }
-
-    public String getProjectAccession() {
-        return projectAccession;
-    }
-
-    public void setProjectAccession(String projectAccession) {
-        this.projectAccession = projectAccession;
-    }
-
-    public String getAssayAccession() {
-        return assayAccession;
-    }
-
-    public void setAssayAccession(String assayAccession) {
-        this.assayAccession = assayAccession;
-    }
-
-    public String getSubmittedSequence() {
-        return submittedSequence;
-    }
-
-    public void setSubmittedSequence(String submittedSequence) {
-        this.submittedSequence = submittedSequence;
-    }
-
-    public List<String> getDescription() {
-        return description;
-    }
-
-    public void setDescription(List<String> description) {
-        this.description = description;
-    }
-
-    public List<String> getAmbiguityGroupSubmittedAccessions() {
-        return ambiguityGroupSubmittedAccessions;
-    }
-
-    public void setAmbiguityGroupSubmittedAccessions(List<String> ambiguityGroupSubmittedAccessions) {
-        this.ambiguityGroupSubmittedAccessions = ambiguityGroupSubmittedAccessions;
-    }
-
-    public Iterable<ModificationProvider> getModifications() {
-
-        List<ModificationProvider> modifications = new ArrayList<ModificationProvider>();
-
-        if (modificationsAsString != null) {
-            for (String mod : modificationsAsString) {
-                if(!mod.isEmpty()) {
-                    modifications.add(ModificationHelper.convertFromString(mod));
-                }
-            }
-        }
-
-        return modifications;
-    }
-
-    public void setModifications(List<ModificationProvider> modifications) {
-
-        if (modifications == null)
-            return;
-
-        List<String> modificationsAsString = new ArrayList<String>();
-        List<String> modificationNames = new ArrayList<String>();
-        List<String> modificationAccessions = new ArrayList<String>();
-
-        for (ModificationProvider modification : modifications) {
-            modificationsAsString.add(ModificationHelper.convertToString(modification));
-            modificationAccessions.add(modification.getAccession());
-            modificationNames.add(modification.getName());
-        }
-
-        this.modificationsAsString = modificationsAsString;
-        this.modificationAccessions = modificationAccessions;
-        this.modificationNames = modificationNames;
-    }
-
-    public void addModification(ModificationProvider modification) {
-
-        if (modificationsAsString == null) {
-            modificationsAsString = new ArrayList<String>();
-        }
-
-        if (modificationAccessions == null) {
-            modificationAccessions = new ArrayList<String>();
-        }
-
-        if (modificationNames == null) {
-            modificationNames = new ArrayList<String>();
-        }
-
-
-        modificationsAsString.add(ModificationHelper.convertToString(modification));
-        modificationAccessions.add(modification.getAccession());
+  public void setModificationNames(List<ModificationProvider> modifications) {
+    this.modificationNames = new ArrayList<>();
+    if (modifications == null && modifications.size()>0) {
+      for (ModificationProvider modification : modifications) {
         modificationNames.add(modification.getName());
+      }
     }
+  }
 
-    public Set<String> getModificationNames() {
-
-        Set<String> modificationNamesSet = new TreeSet<String>();
-        if (modificationNames != null) {
-            modificationNamesSet.addAll(modificationNames);
-        }
-        return modificationNamesSet;
+  public void addModificationName(ModificationProvider modification) {
+    if (modificationNames == null) {
+      modificationNames = new ArrayList<>();
     }
-
-    public Set<String> getModificationAccessions() {
-
-        Set<String> modificationAccessionsSet = new TreeSet<String>();
-        if (modificationAccessions != null) {
-            modificationAccessionsSet.addAll(modificationAccessions);
-        }
-        return modificationAccessionsSet;
+    if (modification!=null) {
+      modificationNames.add(modification.getName());
     }
-
-    public Map<String, String> getModificationAccessionName() {
-
-        Map<String, String> modificationAccessionsNameMap = new TreeMap<String, String>();
-        if (modificationNames != null && modificationAccessions != null) {
-            if (modificationNames.size() == modificationAccessions.size()) {
-                for (int i = 0; i < modificationNames.size(); i++) {
-                    modificationAccessionsNameMap.put(modificationNames.get(i), modificationAccessions.get(i));
-                }
-            }
-        }
-        return modificationAccessionsNameMap;
-    }
-
-    public String getUniprotMapping() {
-        return uniprotMapping;
-    }
-
-    public void setUniprotMapping(String uniprotMapping) {
-        this.uniprotMapping = uniprotMapping;
-    }
-
-    public String getEnsemblMapping() {
-        return ensemblMapping;
-    }
-
-    public void setEnsemblMapping(String ensemblMapping) {
-        this.ensemblMapping = ensemblMapping;
-    }
-
-    public Set<String> getOtherMappings() {
-        return otherMappings;
-    }
-
-    public void setOtherMappings(Set<String> otherMappings) {
-        this.otherMappings = otherMappings;
-    }
-
-    public String getInferredSequence() {
-        return inferredSequence;
-    }
-
-    public void setInferredSequence(String inferredSequence) {
-        this.inferredSequence = inferredSequence;
-    }
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentification.java
@@ -1,6 +1,7 @@
 package uk.ac.ebi.pride.proteinidentificationindex.search.model;
 
 import org.apache.solr.client.solrj.beans.Field;
+import uk.ac.ebi.pride.archive.dataprovider.identification.IdentificationProvider;
 import uk.ac.ebi.pride.archive.dataprovider.identification.ModificationProvider;
 import uk.ac.ebi.pride.indexutils.helpers.ModificationHelper;
 
@@ -10,7 +11,7 @@ import java.util.*;
  * @author Jose A. Dianes
  * @version $Id$
  */
-public class ProteinIdentification {
+public class ProteinIdentification implements IdentificationProvider {
 
   @Field(ProteinIdentificationFields.ID)
   private String id;

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentificationFields.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentificationFields.java
@@ -7,18 +7,8 @@ package uk.ac.ebi.pride.proteinidentificationindex.search.model;
  */
 public class ProteinIdentificationFields {
     public static final String ID = "id";
-    public static final String SUBMITTED_ACCESSION = "submitted_accession";
     public static final String ACCESSION = "accession";
-    public static final String UNIPROT_MAPPING = "uniprot_mapping";
-    public static final String ENSEMBL_MAPPING = "ensembl_mapping";
-    public static final String OTHER_MAPPINGS = "other_mappings";
-    public static final String SUBMITTED_SEQUENCE = "submitted_sequence";
-    public static final String INFERRED_SEQUENCE = "inferred_sequence";
-    public static final String DESCRIPTION = "description";
-    public static final String AMBIGUITY_GROUP = "ambiguity_group";
-    public static final String MODIFICATIONS = "modifications";
     public static final String MOD_NAMES = "mod_names";
-    public static final String MOD_ACCESSIONS = "mod_accessions";
     public static final String PROJECT_ACCESSION = "project_accession";
     public static final String ASSAY_ACCESSION = "assay_accession";
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentificationSummary.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/model/ProteinIdentificationSummary.java
@@ -7,6 +7,5 @@ import org.springframework.data.rest.core.config.Projection;
  */
 @Projection(name = "summary", types = ProteinIdentification.class)
 public interface ProteinIdentificationSummary {
-
     String getAccession();
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationIndexService.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationIndexService.java
@@ -1,11 +1,9 @@
 package uk.ac.ebi.pride.proteinidentificationindex.search.service;
 
 import org.apache.solr.client.solrj.SolrServer;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.solr.UncategorizedSolrException;
 import org.springframework.stereotype.Service;
 import uk.ac.ebi.pride.proteinidentificationindex.search.model.ProteinIdentification;
 import uk.ac.ebi.pride.proteinidentificationindex.search.service.repository.SolrProteinIdentificationRepository;
@@ -23,95 +21,85 @@ import java.util.LinkedList;
 @Service
 public class ProteinIdentificationIndexService {
 
-    private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationIndexService.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationIndexService.class.getName());
 
-    private static final int NUM_TRIES = 10;
-    private static final int SECONDS_TO_WAIT = 30;
-    private static final long MAX_ELAPSED_TIME_PING_QUERY = 10000;
+  private static final int NUM_TRIES = 10;
+  private static final int SECONDS_TO_WAIT = 30;
+  private static final long MAX_ELAPSED_TIME_PING_QUERY = 10000;
 
-    private SolrServer proteinIdentificationServer;
+  private SolrServer proteinIdentificationServer;
 
-    private SolrProteinIdentificationRepository solrProteinIdentificationRepository;
+  private SolrProteinIdentificationRepository solrProteinIdentificationRepository;
 
-    public ProteinIdentificationIndexService(SolrServer proteinIdentificationServer, SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
-        this.proteinIdentificationServer = proteinIdentificationServer;
-        this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
-    }
+  public ProteinIdentificationIndexService(SolrServer proteinIdentificationServer, SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
+    this.proteinIdentificationServer = proteinIdentificationServer;
+    this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+  }
 
-    public void setSolrProteinIdentificationRepository(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
-        this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
-    }
+  public void setSolrProteinIdentificationRepository(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
+    this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+  }
 
-    public boolean save(ProteinIdentification proteinIdentification) {
-        Collection<ProteinIdentification> pii = new LinkedList<ProteinIdentification>();
-        pii.add(proteinIdentification);
-        return save(pii);
-    }
+  public boolean save(ProteinIdentification proteinIdentification) {
+    Collection<ProteinIdentification> proteinIdentifications = new LinkedList<>();
+    proteinIdentifications.add(proteinIdentification);
+    return save(proteinIdentifications);
+  }
 
-    public boolean save(Collection<ProteinIdentification> proteinIdentifications) {
-        if (proteinIdentifications!= null && proteinIdentifications.size()>0) {
-            int numTries = 0;
-            boolean succeed = false;
-            while (numTries < NUM_TRIES && !succeed) {
-                try {
-                    SolrPingResponse pingResponse = this.proteinIdentificationServer.ping();
-                    if ((pingResponse.getStatus() == 0) && pingResponse.getElapsedTime() < MAX_ELAPSED_TIME_PING_QUERY) {
-                        this.proteinIdentificationServer.addBeans(proteinIdentifications);
-                        this.proteinIdentificationServer.commit();
-                        succeed = true;
-                    } else {
-                        logger.error("[TRY " + numTries + " Solr server too busy!");
-                        logger.error("PING response status: " + pingResponse.getStatus());
-                        logger.error("PING elapsed time: " + pingResponse.getElapsedTime());
-                        logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                        waitSecs();
-                    }
-                } catch (SolrServerException e) {
-                    logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
-                    logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                    waitSecs();
-                } catch (UncategorizedSolrException e) {
-                    logger.error("[TRY " + numTries + "] There are server problems: " + e.getCause());
-                    logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                    waitSecs();
-                } catch (Exception e) {
-                    logger.error("[TRY " + numTries + "] There are UNKNOWN problems: " + e.getCause());
-                    e.printStackTrace();
-                    logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
-                    waitSecs();
-                }
-                numTries++;
-            }
-
-            return succeed;
-        } else {
-            logger.error("Protein Identification Index Service [reliable-save]: Trying to save an empty protein list!");
-
-            return false;
-        }
-    }
-
-    public void delete(ProteinIdentification proteinIdentification){
-        solrProteinIdentificationRepository.delete(proteinIdentification);
-    }
-
-    public void delete(Iterable<ProteinIdentification> psms){
-        if (psms==null || !psms.iterator().hasNext())
-            logger.info("No Protein Identifications to delete");
-        else {
-            solrProteinIdentificationRepository.delete(psms);
-        }
-    }
-
-    public void deleteAll() {
-        solrProteinIdentificationRepository.deleteAll();
-    }
-
-    private void waitSecs() {
+  public boolean save(Collection<ProteinIdentification> proteinIdentifications) {
+    if (proteinIdentifications!= null && proteinIdentifications.size()>0) {
+      int numTries = 0;
+      boolean succeed = false;
+      while (numTries < NUM_TRIES) {
         try {
-            Thread.sleep(SECONDS_TO_WAIT * 1000);
-        } catch (InterruptedException e1) {
-            e1.printStackTrace();
+          SolrPingResponse pingResponse = this.proteinIdentificationServer.ping();
+          if ((pingResponse.getStatus() == 0) && pingResponse.getElapsedTime() < MAX_ELAPSED_TIME_PING_QUERY) {
+            this.proteinIdentificationServer.addBeans(proteinIdentifications);
+            this.proteinIdentificationServer.commit();
+            succeed = true;
+            break;
+          } else {
+            logger.error("[TRY " + numTries + " Solr server too busy!");
+            logger.error("PING response status: " + pingResponse.getStatus());
+            logger.error("PING elapsed time: " + pingResponse.getElapsedTime());
+            logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+            waitSecs();
+          }
+        } catch (Exception e) {
+          logger.error("[TRY " + numTries + "] There are server problems: ", e);
+          logger.error("Re-trying in " + SECONDS_TO_WAIT + " seconds...");
+          waitSecs();
         }
+        numTries++;
+      }
+      return succeed;
+    } else {
+      logger.error("Protein Identification Index Service [reliable-save]: Trying to save an empty protein list!");
+      return false;
     }
+  }
+
+  public void delete(ProteinIdentification proteinIdentification){
+    solrProteinIdentificationRepository.delete(proteinIdentification);
+  }
+
+  public void delete(Iterable<ProteinIdentification> proteinIdentifications){
+    if (proteinIdentifications ==null || !proteinIdentifications.iterator().hasNext())
+      logger.info("No Protein Identifications to delete");
+    else {
+      solrProteinIdentificationRepository.delete(proteinIdentifications);
+    }
+  }
+
+  public void deleteAll() {
+    solrProteinIdentificationRepository.deleteAll();
+  }
+
+  private void waitSecs() {
+    try {
+      Thread.sleep(SECONDS_TO_WAIT * 1000);
+    } catch (InterruptedException e1) {
+      e1.printStackTrace();
+    }
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
@@ -105,6 +105,18 @@ public class ProteinIdentificationSearchService {
     return solrProteinIdentificationRepository.findByAssayAccessionIn(assayAccessions, pageable);
   }
 
+  public List<ProteinIdentification> findByAssayAccessionAndAccession(String assayAccession, String accession) {
+    return solrProteinIdentificationRepository.findByAssayAccessionAndAccession(assayAccession, accession);
+  }
+
+  public Page<ProteinIdentification> findByAssayAccessionAndAccession(String assayAccession, String accession, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByAssayAccessionAndAccession(assayAccession, accession, pageable);
+  }
+
+  public Long countByAssayAccessionAndAccession(String assayAccession, String accession) {
+    return solrProteinIdentificationRepository.countByAssayAccessionAndAccession(assayAccession, accession);
+  }
+
   /**
    * Count the facets per modification name
    * @param assayAccession mandatory

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
@@ -145,11 +145,11 @@ public class ProteinIdentificationSearchService {
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
       proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, new PageRequest(0, 1));
     } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, term, term, new PageRequest(0, 1));
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, term, new PageRequest(0, 1));
     } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
       proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, modNameFilters, new PageRequest(0, 1));
     } else {
-      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, term, term, modNameFilters, new PageRequest(0, 1));
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, term, modNameFilters, new PageRequest(0, 1));
     }
     if (proteinIdentifications != null) {
       for (FacetFieldEntry facetFieldEntry : proteinIdentifications.getFacetResultPage(ProteinIdentificationFields.MOD_NAMES)) {
@@ -198,11 +198,11 @@ public class ProteinIdentificationSearchService {
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
       proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable));
     } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, term, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, pageable));
     } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
       proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionAndFilterModNames(projectAccession, modNameFilters, pageable));
     } else {
-      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, term, modNameFilters, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, modNameFilters, pageable));
     }
     return proteinIdentifications;
   }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
@@ -25,227 +25,217 @@ import java.util.*;
 @Service
 public class ProteinIdentificationSearchService {
 
-    private SolrProteinIdentificationRepository solrProteinIdentificationRepository;
+  private SolrProteinIdentificationRepository solrProteinIdentificationRepository;
 
-    public ProteinIdentificationSearchService(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
-        this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+  public ProteinIdentificationSearchService(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
+    this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+  }
+
+  public void setSolrProteinIdentificationRepository(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
+    this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+  }
+
+  // find by id methods
+  public List<ProteinIdentification> findById(String id) {
+    return solrProteinIdentificationRepository.findById(id);
+  }
+
+  public List<ProteinIdentification> findById(Collection<String> ids) {
+    return solrProteinIdentificationRepository.findByIdIn(ids);
+  }
+
+  // find by accession methods
+  public List<ProteinIdentification> findByAccession(String accession) {
+    return solrProteinIdentificationRepository.findByAccession(accession);
+  }
+
+  public List<ProteinIdentification> findByAccession(Collection<String> accessions) {
+    return solrProteinIdentificationRepository.findByAccessionIn(accessions);
+  }
+
+  // Project accession query methods
+  public List<ProteinIdentification> findByProjectAccession(String projectAccession) {
+    return solrProteinIdentificationRepository.findByProjectAccession(projectAccession);
+  }
+  public Long countByProjectAccession(String projectAccession) {
+    return solrProteinIdentificationRepository.countByProjectAccession(projectAccession);
+  }
+
+  public List<ProteinIdentification> findByProjectAccession(Collection<String> projectAccessions) {
+    return solrProteinIdentificationRepository.findByProjectAccessionIn(projectAccessions);
+  }
+
+  public Page<ProteinIdentification> findByProjectAccession(String projectAccession, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable);
+  }
+
+  public Page<ProteinIdentification> findByProjectAccession(Collection<String> projectAccessions, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByProjectAccessionIn(projectAccessions, pageable);
+  }
+
+  public List<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession) {
+    return solrProteinIdentificationRepository.findByProjectAccessionAndAccession(projectAccession, accession);
+  }
+
+  public Page<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByProjectAccessionAndAccession(projectAccession, accession, pageable);
+  }
+
+  public Long countByProjectAccessionAndAccession(String projectAccession, String accession) {
+    return solrProteinIdentificationRepository.countByProjectAccessionAndAccession(projectAccession, accession);
+  }
+
+  // Assay accession query methods
+  public List<ProteinIdentification> findByAssayAccession(String assayAccession) {
+    return solrProteinIdentificationRepository.findByAssayAccession(assayAccession);
+  }
+  public Long countByAssayAccession(String assayAccession) {
+    return solrProteinIdentificationRepository.countByAssayAccession(assayAccession);
+  }
+
+  public List<ProteinIdentification> findByAssayAccession(Collection<String> assayAccessions) {
+    return solrProteinIdentificationRepository.findByAssayAccessionIn(assayAccessions);
+  }
+
+  public Page<ProteinIdentification> findByAssayAccession(String assayAccession, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable);
+  }
+
+  public Page<ProteinIdentification> findByAssayAccession(Collection<String> assayAccessions, Pageable pageable) {
+    return solrProteinIdentificationRepository.findByAssayAccessionIn(assayAccessions, pageable);
+  }
+
+  /**
+   * Count the facets per modification name
+   * @param assayAccession mandatory
+   * @param term optional
+   * @param modNameFilters optional
+   * @return a map with the mod_names and the number of hits per mod_synonym
+   */
+  public Map<String, Long> findByAssayAccessionFacetOnModificationNames(String assayAccession, String term, List<String> modNameFilters) {
+    Map<String, Long> modificationsCount = new TreeMap<String, Long>();
+    FacetPage<ProteinIdentification> proteinIdentifications;
+    if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNames(assayAccession, new PageRequest(0, 1));
+    } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNames(assayAccession, term, term, new PageRequest(0, 1));
+    } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNamesAndFilterModNames(assayAccession, modNameFilters, new PageRequest(0, 1));
+    } else {
+      proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNamesAndFilterModNames(assayAccession, term, term, modNameFilters, new PageRequest(0, 1));
     }
-
-    public void setSolrProteinIdentificationRepository(SolrProteinIdentificationRepository solrProteinIdentificationRepository) {
-        this.solrProteinIdentificationRepository = solrProteinIdentificationRepository;
+    if (proteinIdentifications != null) {
+      for (FacetFieldEntry facetFieldEntry : proteinIdentifications.getFacetResultPage(ProteinIdentificationFields.MOD_NAMES)) {
+        modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
+      }
     }
+    return modificationsCount;
+  }
 
-    // find by id methods
-    public List<ProteinIdentification> findById(String id) {
-        return solrProteinIdentificationRepository.findById(id);
+  /**
+   * Count the facets per modification name
+   * @param projectAccession mandatory
+   * @param term optional
+   * @param modNameFilters optional
+   * @return a map with the mod_names and the number of hits per mod_synonym
+   */
+  public Map<String, Long> findByProjectAccessionFacetOnModificationNames(String projectAccession, String term, List<String> modNameFilters) {
+    Map<String, Long> modificationsCount = new TreeMap<String, Long>();
+    FacetPage<ProteinIdentification> proteinIdentifications;
+    if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, new PageRequest(0, 1));
+    } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, term, term, new PageRequest(0, 1));
+    } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, modNameFilters, new PageRequest(0, 1));
+    } else {
+      proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, term, term, modNameFilters, new PageRequest(0, 1));
     }
-
-    public List<ProteinIdentification> findById(Collection<String> ids) {
-        return solrProteinIdentificationRepository.findByIdIn(ids);
+    if (proteinIdentifications != null) {
+      for (FacetFieldEntry facetFieldEntry : proteinIdentifications.getFacetResultPage(ProteinIdentificationFields.MOD_NAMES)) {
+        modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
+      }
     }
+    return modificationsCount;
+  }
 
-    // find by accession methods
-    public List<ProteinIdentification> findByAccession(String accession) {
-        return solrProteinIdentificationRepository.findByAccession(accession);
+  /**
+   * Return protein identifications filtered (or not) by modifications names with the highlights for modification names
+   *
+   * @param assayAccession mandatory
+   * @param term optional
+   * @param modNameFilters optional
+   * @param pageable requested page
+   * @return A page with the protein identifications and the highlights snippets
+   */
+  public PageWrapper<ProteinIdentification> findByAssayAccessionHighlightsOnModificationNames(
+      String assayAccession, String term, List<String> modNameFilters, Pageable pageable) {
+    PageWrapper<ProteinIdentification> proteinIdentifications;
+    if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable));
+    } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlights(assayAccession, term, term, pageable));
+    } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionAndFilterModNames(assayAccession, modNameFilters, pageable));
+    } else {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlightsAndFilterModNames(assayAccession, term, term, modNameFilters, pageable));
     }
+    return proteinIdentifications;
+  }
 
-    public List<ProteinIdentification> findByAccession(Collection<String> accessions) {
-        return solrProteinIdentificationRepository.findByAccessionIn(accessions);
+  /**
+   * Return protein identifications filtered (or not) by modifications names with the highlights for modification names
+   *
+   * @param projectAccession mandatory
+   * @param term optional
+   * @param modNameFilters optional
+   * @param pageable requested page
+   * @return A page with the protein identifications and the highlights snippets
+   */
+  public PageWrapper<ProteinIdentification> findByProjectAccessionHighlightsOnModificationNames(
+      String projectAccession, String term, List<String> modNameFilters, Pageable pageable) {
+    PageWrapper<ProteinIdentification> proteinIdentifications;
+    if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable));
+    } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, term, pageable));
+    } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionAndFilterModNames(projectAccession, modNameFilters, pageable));
+    } else {
+      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, term, modNameFilters, pageable));
     }
+    return proteinIdentifications;
+  }
 
-    // Project accession query methods
-    public List<ProteinIdentification> findByProjectAccession(String projectAccession) {
-        return solrProteinIdentificationRepository.findByProjectAccession(projectAccession);
+  public List<ProteinIdentificationSummary> findSummaryByProjectAccession(String projectAccession) {
+    return solrProteinIdentificationRepository.findSummaryByProjectAccession(projectAccession);
+  }
+
+  public Set<String> getUniqueProteinAccessionsByProjectAccession(String projectAccession) {
+    List<ProteinIdentificationSummary> results = findSummaryByProjectAccession(projectAccession);
+    Set<String> accessions = new HashSet<String>(results.size());
+    Iterator<ProteinIdentificationSummary> iterator = results.iterator();
+    while (iterator.hasNext()) {
+      // in order to make it work we need to cast to the real bean before accessing data
+      ProteinIdentification ident = (ProteinIdentification) iterator.next();
+      accessions.add(ident.getAccession());
     }
-    public Long countByProjectAccession(String projectAccession) {
-        return solrProteinIdentificationRepository.countByProjectAccession(projectAccession);
+    return accessions;
+  }
+
+  public List<ProteinIdentificationSummary> findSummaryByAssayAccession(String assayAccession) {
+    return solrProteinIdentificationRepository.findSummaryByAssayAccession(assayAccession);
+  }
+
+  public Set<String> getUniqueProteinAccessionsByAssayAccession(String assayAccession) {
+    List<ProteinIdentificationSummary> results = findSummaryByAssayAccession(assayAccession);
+    Set<String> accessions = new HashSet<String>(results.size());
+    Iterator<ProteinIdentificationSummary> iterator = results.iterator();
+    while (iterator.hasNext()) {
+      // in order to make it work we need to cast to the real bean before accessing data
+      ProteinIdentification ident = (ProteinIdentification) iterator.next();
+      accessions.add(ident.getAccession());
     }
-
-    public List<ProteinIdentification> findByProjectAccession(Collection<String> projectAccessions) {
-        return solrProteinIdentificationRepository.findByProjectAccessionIn(projectAccessions);
-    }
-
-    // Mapping query methods
-    public List<ProteinIdentification> findByProjectAccessionAndAnyMapping(String projectAccession, String accession) {
-        return solrProteinIdentificationRepository.findByProjectAccessionAndAnyMapping(projectAccession, accession, accession);
-    }
-
-    public Page<ProteinIdentification> findByProjectAccession(String projectAccession, Pageable pageable) {
-        return solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable);
-    }
-
-    public Page<ProteinIdentification> findByProjectAccession(Collection<String> projectAccessions, Pageable pageable) {
-        return solrProteinIdentificationRepository.findByProjectAccessionIn(projectAccessions, pageable);
-    }
-
-    // Assay accession query methods
-    public List<ProteinIdentification> findByAssayAccession(String assayAccession) {
-        return solrProteinIdentificationRepository.findByAssayAccession(assayAccession);
-    }
-    public Long countByAssayAccession(String assayAccession) {
-        return solrProteinIdentificationRepository.countByAssayAccession(assayAccession);
-    }
-
-    public List<ProteinIdentification> findByAssayAccession(Collection<String> assayAccessions) {
-        return solrProteinIdentificationRepository.findByAssayAccessionIn(assayAccessions);
-    }
-
-    public Page<ProteinIdentification> findByAssayAccession(String assayAccession, Pageable pageable) {
-        return solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable);
-    }
-
-    public Page<ProteinIdentification> findByAssayAccession(Collection<String> assayAccessions, Pageable pageable) {
-        return solrProteinIdentificationRepository.findByAssayAccessionIn(assayAccessions, pageable);
-    }
-
-    /**
-     * Count the facets per modification name
-     * @param assayAccession mandatory
-     * @param term optional
-     * @param modNameFilters optional
-     * @return a map with the mod_names and the number of hits per mod_synonym
-     */
-    public Map<String, Long> findByAssayAccessionFacetOnModificationNames(String assayAccession, String term, List<String> modNameFilters) {
-
-        Map<String, Long> modificationsCount = new TreeMap<String, Long>();
-        FacetPage<ProteinIdentification> proteinIdentifications;
-
-        if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNames(assayAccession, new PageRequest(0, 1));
-        } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNames(assayAccession, term, term, new PageRequest(0, 1));
-        } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNamesAndFilterModNames(assayAccession, modNameFilters, new PageRequest(0, 1));
-        } else {
-            proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNamesAndFilterModNames(assayAccession, term, term, modNameFilters, new PageRequest(0, 1));
-        }
-
-        if (proteinIdentifications != null) {
-            for (FacetFieldEntry facetFieldEntry : proteinIdentifications.getFacetResultPage(ProteinIdentificationFields.MOD_NAMES)) {
-                modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
-            }
-        }
-        return modificationsCount;
-    }
-
-    /**
-     * Count the facets per modification name
-     * @param projectAccession mandatory
-     * @param term optional
-     * @param modNameFilters optional
-     * @return a map with the mod_names and the number of hits per mod_synonym
-     */
-    public Map<String, Long> findByProjectAccessionFacetOnModificationNames(String projectAccession, String term, List<String> modNameFilters) {
-
-        Map<String, Long> modificationsCount = new TreeMap<String, Long>();
-        FacetPage<ProteinIdentification> proteinIdentifications;
-
-        if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, new PageRequest(0, 1));
-        } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, term, term, new PageRequest(0, 1));
-        } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-            proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, modNameFilters, new PageRequest(0, 1));
-        } else {
-            proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNamesAndFilterModNames(projectAccession, term, term, modNameFilters, new PageRequest(0, 1));
-        }
-
-        if (proteinIdentifications != null) {
-            for (FacetFieldEntry facetFieldEntry : proteinIdentifications.getFacetResultPage(ProteinIdentificationFields.MOD_NAMES)) {
-                modificationsCount.put(facetFieldEntry.getValue(), facetFieldEntry.getValueCount());
-            }
-        }
-        return modificationsCount;
-    }
-
-    /**
-     * Return protein identifications filtered (or not) by modifications names with the highlights for modification names
-     *
-     * @param assayAccession mandatory
-     * @param term optional
-     * @param modNameFilters optional
-     * @param pageable requested page
-     * @return A page with the protein identifications and the highlights snippets
-     */
-    public PageWrapper<ProteinIdentification> findByAssayAccessionHighlightsOnModificationNames(
-            String assayAccession, String term, List<String> modNameFilters, Pageable pageable) {
-
-        PageWrapper<ProteinIdentification> proteinIdentifications;
-
-        if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable));
-        } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlights(assayAccession, term, term, pageable));
-        } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionAndFilterModNames(assayAccession, modNameFilters, pageable));
-        } else {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlightsAndFilterModNames(assayAccession, term, term, modNameFilters, pageable));
-        }
-
-        return proteinIdentifications;
-    }
-
-    /**
-     * Return protein identifications filtered (or not) by modifications names with the highlights for modification names
-     *
-     * @param projectAccession mandatory
-     * @param term optional
-     * @param modNameFilters optional
-     * @param pageable requested page
-     * @return A page with the protein identifications and the highlights snippets
-     */
-    public PageWrapper<ProteinIdentification> findByProjectAccessionHighlightsOnModificationNames(
-            String projectAccession, String term, List<String> modNameFilters, Pageable pageable) {
-
-        PageWrapper<ProteinIdentification> proteinIdentifications;
-
-        if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable));
-        } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, term, pageable));
-        } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionAndFilterModNames(projectAccession, modNameFilters, pageable));
-        } else {
-            proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, term, modNameFilters, pageable));
-        }
-
-        return proteinIdentifications;
-    }
-
-    // Submitted accession query methods
-    public List<ProteinIdentification> findBySubmittedAccessionAndAssayAccession(String submittedAccession, String assayAccession){
-        return solrProteinIdentificationRepository.findBySubmittedAccessionAndAssayAccession(submittedAccession, assayAccession);
-    }
-
-    public List<ProteinIdentificationSummary> findSummaryByProjectAccession(String projectAccession) {
-        return solrProteinIdentificationRepository.findSummaryByProjectAccession(projectAccession);
-    }
-
-    public Set<String> getUniqueProteinAccessionsByProjectAccession(String projectAccession) {
-        List<ProteinIdentificationSummary> results = findSummaryByProjectAccession(projectAccession);
-        Set<String> accessions = new HashSet<String>(results.size());
-        Iterator<ProteinIdentificationSummary> iterator = results.iterator();
-        while (iterator.hasNext()) {
-            // in order to make it work we need to cast to the real bean before accessing data
-            ProteinIdentification ident = (ProteinIdentification) iterator.next();
-            accessions.add(ident.getAccession());
-        }
-        return accessions;
-    }
-
-    public List<ProteinIdentificationSummary> findSummaryByAssayAccession(String assayAccession) {
-        return solrProteinIdentificationRepository.findSummaryByAssayAccession(assayAccession);
-    }
-
-    public Set<String> getUniqueProteinAccessionsByAssayAccession(String assayAccession) {
-        List<ProteinIdentificationSummary> results = findSummaryByAssayAccession(assayAccession);
-        Set<String> accessions = new HashSet<String>(results.size());
-        Iterator<ProteinIdentificationSummary> iterator = results.iterator();
-        while (iterator.hasNext()) {
-            // in order to make it work we need to cast to the real bean before accessing data
-            ProteinIdentification ident = (ProteinIdentification) iterator.next();
-            accessions.add(ident.getAccession());
-        }
-        return accessions;
-    }
+    return accessions;
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/ProteinIdentificationSearchService.java
@@ -113,7 +113,7 @@ public class ProteinIdentificationSearchService {
    * @return a map with the mod_names and the number of hits per mod_synonym
    */
   public Map<String, Long> findByAssayAccessionFacetOnModificationNames(String assayAccession, String term, List<String> modNameFilters) {
-    Map<String, Long> modificationsCount = new TreeMap<String, Long>();
+    Map<String, Long> modificationsCount = new TreeMap<>();
     FacetPage<ProteinIdentification> proteinIdentifications;
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
       proteinIdentifications = solrProteinIdentificationRepository.findByAssayAccessionFacetModNames(assayAccession, new PageRequest(0, 1));
@@ -140,7 +140,7 @@ public class ProteinIdentificationSearchService {
    * @return a map with the mod_names and the number of hits per mod_synonym
    */
   public Map<String, Long> findByProjectAccessionFacetOnModificationNames(String projectAccession, String term, List<String> modNameFilters) {
-    Map<String, Long> modificationsCount = new TreeMap<String, Long>();
+    Map<String, Long> modificationsCount = new TreeMap<>();
     FacetPage<ProteinIdentification> proteinIdentifications;
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
       proteinIdentifications = solrProteinIdentificationRepository.findByProjectAccessionFacetModNames(projectAccession, new PageRequest(0, 1));
@@ -172,13 +172,13 @@ public class ProteinIdentificationSearchService {
       String assayAccession, String term, List<String> modNameFilters, Pageable pageable) {
     PageWrapper<ProteinIdentification> proteinIdentifications;
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByAssayAccession(assayAccession, pageable));
     } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlights(assayAccession, term, term, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByAssayAccessionHighlights(assayAccession, term, term, pageable));
     } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionAndFilterModNames(assayAccession, modNameFilters, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByAssayAccessionAndFilterModNames(assayAccession, modNameFilters, pageable));
     } else {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByAssayAccessionHighlightsAndFilterModNames(assayAccession, term, term, modNameFilters, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByAssayAccessionHighlightsAndFilterModNames(assayAccession, term, term, modNameFilters, pageable));
     }
     return proteinIdentifications;
   }
@@ -196,13 +196,13 @@ public class ProteinIdentificationSearchService {
       String projectAccession, String term, List<String> modNameFilters, Pageable pageable) {
     PageWrapper<ProteinIdentification> proteinIdentifications;
     if ((term == null || term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccession(projectAccession, pageable));
     } else if ((term != null && !term.isEmpty()) && (modNameFilters == null || modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, term, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlights(projectAccession, term, term, pageable));
     } else if ((term == null || term.isEmpty()) && (modNameFilters != null && !modNameFilters.isEmpty())) {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionAndFilterModNames(projectAccession, modNameFilters, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionAndFilterModNames(projectAccession, modNameFilters, pageable));
     } else {
-      proteinIdentifications = new PageWrapper<ProteinIdentification>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, term, modNameFilters, pageable));
+      proteinIdentifications = new PageWrapper<>(solrProteinIdentificationRepository.findByProjectAccessionHighlightsAndFilterModNames(projectAccession, term, term, modNameFilters, pageable));
     }
     return proteinIdentifications;
   }
@@ -213,11 +213,9 @@ public class ProteinIdentificationSearchService {
 
   public Set<String> getUniqueProteinAccessionsByProjectAccession(String projectAccession) {
     List<ProteinIdentificationSummary> results = findSummaryByProjectAccession(projectAccession);
-    Set<String> accessions = new HashSet<String>(results.size());
-    Iterator<ProteinIdentificationSummary> iterator = results.iterator();
-    while (iterator.hasNext()) {
-      // in order to make it work we need to cast to the real bean before accessing data
-      ProteinIdentification ident = (ProteinIdentification) iterator.next();
+    Set<String> accessions = new HashSet<>(results.size());
+    for (ProteinIdentificationSummary result : results) {
+      ProteinIdentification ident = (ProteinIdentification) result; // need to cast to the real bean before accessing data
       accessions.add(ident.getAccession());
     }
     return accessions;
@@ -229,11 +227,9 @@ public class ProteinIdentificationSearchService {
 
   public Set<String> getUniqueProteinAccessionsByAssayAccession(String assayAccession) {
     List<ProteinIdentificationSummary> results = findSummaryByAssayAccession(assayAccession);
-    Set<String> accessions = new HashSet<String>(results.size());
-    Iterator<ProteinIdentificationSummary> iterator = results.iterator();
-    while (iterator.hasNext()) {
-      // in order to make it work we need to cast to the real bean before accessing data
-      ProteinIdentification ident = (ProteinIdentification) iterator.next();
+    Set<String> accessions = new HashSet<>(results.size());
+    for (ProteinIdentificationSummary result : results) {
+      ProteinIdentification ident = (ProteinIdentification) result; // need to cast to the real bean before accessing data
       accessions.add(ident.getAccession());
     }
     return accessions;

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -49,11 +49,11 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     @Query("project_accession:(?0)")
     Page<ProteinIdentification> findByProjectAccessionIn(Collection<String> projectAccessions, Pageable pageable);
 
-    @Query("project_accession:?0 AND assay_accession:?1")
+    @Query("project_accession:?0 AND accession:?1")
     List<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession);
-    @Query("project_accession:?0 AND assay_accession:?1")
+    @Query("project_accession:?0 AND accession:?1")
     Page<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession, Pageable pageable);
-    @Query("project_accession:?0 AND assay_accession:?1")
+    @Query("project_accession:?0 AND accession:?1")
     Long countByProjectAccessionAndAccession(String projectAccession, String accession);
 
     @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -39,7 +39,6 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     List<ProteinIdentification> findByAccessionIn(Collection<String> accession);
 
     // Project accession query methods
-    @Query("project_accession:?0")
     Long countByProjectAccession(String projectAccession);
     @Query("project_accession:?0")
     List<ProteinIdentification> findByProjectAccession(String projectAccession);
@@ -54,7 +53,6 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     List<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession);
     @Query("project_accession:?0 AND accession:?1")
     Page<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession, Pageable pageable);
-    @Query("project_accession:?0 AND accession:?1")
     Long countByProjectAccessionAndAccession(String projectAccession, String accession);
 
     @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -49,12 +49,12 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     @Query("project_accession:(?0)")
     Page<ProteinIdentification> findByProjectAccessionIn(Collection<String> projectAccessions, Pageable pageable);
 
-    @Query("peptide_sequence:?0 AND assay_accession:?1")
+    @Query("project_accession:?0 AND assay_accession:?1")
     List<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession);
-    @Query("peptide_sequence:?0 AND assay_accession:?1")
+    @Query("project_accession:?0 AND assay_accession:?1")
     Page<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession, Pageable pageable);
-    @Query("peptide_sequence:?0 AND assay_accession:?1")
-    Long countByProjectAccessionAndAccession(String peptideSequence, String accession);
+    @Query("project_accession:?0 AND assay_accession:?1")
+    Long countByProjectAccessionAndAccession(String projectAccession, String accession);
 
     @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
     Page<ProteinIdentification> findByProjectAccessionAndFilterModNames(String projectAccessions, List<String> modNameFilters, Pageable pageable);

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -92,6 +92,11 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     Page<ProteinIdentification> findByAssayAccession(String assayAccession, Pageable pageable);
     @Query("assay_accession:(?0)")
     Page<ProteinIdentification> findByAssayAccessionIn(Collection<String> assayAccessions, Pageable pageable);
+    @Query("assay_accession:?0 AND accession:?1")
+    List<ProteinIdentification> findByAssayAccessionAndAccession(String assayAccession, String accession);
+    @Query("assay_accession:?0 AND accession:?1")
+    Page<ProteinIdentification> findByAssayAccessionAndAccession(String assayAccession, String accession, Pageable pageable);
+    Long countByAssayAccessionAndAccession(String assayAccession, String accession);
 
     @Query(value = "assay_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
     Page<ProteinIdentification> findByAssayAccessionAndFilterModNames(String assayAccession, List<String> modNameFilters, Pageable pageable);

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -59,12 +59,12 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     Page<ProteinIdentification> findByProjectAccessionAndFilterModNames(String projectAccessions, List<String> modNameFilters, Pageable pageable);
 
     @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
-    @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
-    HighlightPage<ProteinIdentification> findByProjectAccessionHighlights(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
+    @Query(value = "project_accession:?0 AND accession:?1")
+    HighlightPage<ProteinIdentification> findByProjectAccessionHighlights(String projectAccessions, String term, Pageable pageable);
 
     @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
-    @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)", filters = "mod_names:(?3)", defaultOperator = AND)
-    HighlightPage<ProteinIdentification> findByProjectAccessionHighlightsAndFilterModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
+    @Query(value = "project_accession:?0 AND accession:?1", filters = "mod_names:(?2)", defaultOperator = AND)
+    HighlightPage<ProteinIdentification> findByProjectAccessionHighlightsAndFilterModNames(String projectAccessions, String term, List<String> modNameFilters, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
     @Query(value = "project_accession:?0")
@@ -72,7 +72,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
 
     @Facet(fields = {"mod_names"}, limit = 100)
     @Query(value = "project_accession:?0 AND accession:?1")
-    FacetPage<ProteinIdentification> findByProjectAccessionFacetModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
+    FacetPage<ProteinIdentification> findByProjectAccessionFacetModNames(String projectAccessions, String term, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
     @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
@@ -80,8 +80,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
 
     @Facet(fields = {"mod_names"}, limit = 100)
     @Query(value = "project_accession:?0 AND accession:?1", filters = "mod_names:(?2)", defaultOperator = AND)
-    FacetPage<ProteinIdentification> findByProjectAccessionFacetModNamesAndFilterModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
-
+    FacetPage<ProteinIdentification> findByProjectAccessionFacetModNamesAndFilterModNames(String projectAccessions, String term, List<String> modNameFilters, Pageable pageable);
 
     // Assay accession query methods
     Long countByAssayAccession(String assayAccession);
@@ -102,7 +101,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     HighlightPage<ProteinIdentification> findByAssayAccessionHighlights(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
 
     @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
-    @Query(value = "assay_accession:?0 AND  accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
+    @Query(value = "assay_accession:?0 AND  accession:?1", filters = "mod_names:(?2)", defaultOperator = AND)
     HighlightPage<ProteinIdentification> findByAssayAccessionHighlightsAndFilterModNames(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -39,6 +39,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     List<ProteinIdentification> findByAccessionIn(Collection<String> accession);
 
     // Project accession query methods
+    @Query("project_accession:?0")
     Long countByProjectAccession(String projectAccession);
     @Query("project_accession:?0")
     List<ProteinIdentification> findByProjectAccession(String projectAccession);

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepository.java
@@ -38,26 +38,6 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     @Query("accession:(?0)")
     List<ProteinIdentification> findByAccessionIn(Collection<String> accession);
 
-    // Mapping query methods
-    @Query("uniprot_mapping:?0")
-    List<ProteinIdentification> findByUniprotMapping(String uniprotMapping);
-    @Query("uniprot_mapping:(?0)")
-    List<ProteinIdentification> findByUniprotMappingIn(Collection<String> uniprotMappings);
-    @Query("ensembl_mapping:?0")
-    List<ProteinIdentification> findByEnsemblMapping(String ensemblMapping);
-    @Query("ensembl_mapping:(?0)")
-    List<ProteinIdentification> findByEnsemblMappingIn(Collection<String> ensemblMappings);
-    @Query("uniprot_mapping:?0 OR ensembl_mapping:?0")
-    List<ProteinIdentification> findByUniprotMappingOrEnsemblMapping(String mapping);
-    @Query("uniprot_mapping:(?0) OR ensembl_mapping:(?0)")
-    List<ProteinIdentification> findByUniprotMappingOrEnsemblMappingIn(Collection<String> mappings);
-    @Query("other_mappings:?0")
-    List<ProteinIdentification> findByOtherMapping(String otherMapping);
-    @Query("other_mappings:(?0)")
-    List<ProteinIdentification> findByOtherMappingIn(Collection<String> otherMappings);
-    @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
-    List<ProteinIdentification> findByProjectAccessionAndAnyMapping(String projectAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm);
-
     // Project accession query methods
     Long countByProjectAccession(String projectAccession);
     @Query("project_accession:?0")
@@ -69,14 +49,21 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     @Query("project_accession:(?0)")
     Page<ProteinIdentification> findByProjectAccessionIn(Collection<String> projectAccessions, Pageable pageable);
 
+    @Query("peptide_sequence:?0 AND assay_accession:?1")
+    List<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession);
+    @Query("peptide_sequence:?0 AND assay_accession:?1")
+    Page<ProteinIdentification> findByProjectAccessionAndAccession(String projectAccession, String accession, Pageable pageable);
+    @Query("peptide_sequence:?0 AND assay_accession:?1")
+    Long countByProjectAccessionAndAccession(String peptideSequence, String accession);
+
     @Query(value = "project_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
     Page<ProteinIdentification> findByProjectAccessionAndFilterModNames(String projectAccessions, List<String> modNameFilters, Pageable pageable);
 
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"submitted_accession, accession, ambiguity_group, uniprot_mapping, ensembl_mapping, other_mappings"})
+    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
     @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
     HighlightPage<ProteinIdentification> findByProjectAccessionHighlights(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
 
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"submitted_accession, accession, ambiguity_group, uniprot_mapping, ensembl_mapping, other_mappings"})
+    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
     @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)", filters = "mod_names:(?3)", defaultOperator = AND)
     HighlightPage<ProteinIdentification> findByProjectAccessionHighlightsAndFilterModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
 
@@ -85,7 +72,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     FacetPage<ProteinIdentification> findByProjectAccessionFacetModNames(String projectAccessions, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
+    @Query(value = "project_accession:?0 AND accession:?1")
     FacetPage<ProteinIdentification> findByProjectAccessionFacetModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
@@ -93,7 +80,7 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     FacetPage<ProteinIdentification> findByProjectAccessionFacetModNamesAndFilterModNames(String projectAccessions, List<String> modNameFilters, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "project_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)", filters = "mod_names:(?3)", defaultOperator = AND)
+    @Query(value = "project_accession:?0 AND accession:?1", filters = "mod_names:(?2)", defaultOperator = AND)
     FacetPage<ProteinIdentification> findByProjectAccessionFacetModNamesAndFilterModNames(String projectAccessions, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
 
 
@@ -111,16 +98,16 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     @Query(value = "assay_accession:?0", filters = "mod_names:(?1)", defaultOperator = AND)
     Page<ProteinIdentification> findByAssayAccessionAndFilterModNames(String assayAccession, List<String> modNameFilters, Pageable pageable);
 
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"submitted_accession, accession, ambiguity_group, uniprot_mapping, ensembl_mapping, other_mappings"})
-    @Query(value = "assay_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
+    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
+    @Query(value = "assay_accession:?0 AND accession:?1")
     HighlightPage<ProteinIdentification> findByAssayAccessionHighlights(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
 
-    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"submitted_accession, accession, ambiguity_group, uniprot_mapping, ensembl_mapping, other_mappings"})
-    @Query(value = "assay_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)", filters = "mod_names:(?3)", defaultOperator = AND)
+    @Highlight(prefix = HIGHLIGHT_PRE_FRAGMENT, postfix = HIGHLIGHT_POST_FRAGMENT, fields = {"accession"})
+    @Query(value = "assay_accession:?0 AND  accession:?1)", filters = "mod_names:(?2)", defaultOperator = AND)
     HighlightPage<ProteinIdentification> findByAssayAccessionHighlightsAndFilterModNames(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "assay_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1 OR ambiguity_group:?1 OR other_mappings:?2)")
+    @Query(value = "assay_accession:?0 AND accession:?1")
     FacetPage<ProteinIdentification> findByAssayAccessionFacetModNames(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
@@ -132,13 +119,8 @@ public interface SolrProteinIdentificationRepository extends SolrCrudRepository<
     FacetPage<ProteinIdentification> findByAssayAccessionFacetModNamesAndFilterModNames(String assayAccession, List<String> modNameFilters, Pageable pageable);
 
     @Facet(fields = {"mod_names"}, limit = 100)
-    @Query(value = "assay_accession:?0 AND (submitted_accession:?1 OR accession:?1 OR uniprot_mapping:?1 OR ensembl_mapping:?1  OR ambiguity_group:?1 OR other_mappings:?2)", filters = "mod_names:(?3)", defaultOperator = AND)
+    @Query(value = "assay_accession:?0 AND accession:?1", filters = "mod_names:(?2)", defaultOperator = AND)
     FacetPage<ProteinIdentification> findByAssayAccessionFacetModNamesAndFilterModNames(String assayAccession, @Boost(TERM_BOOST) String term, @Boost(SECONDARY_TERM_BOOST) String secondaryTerm, List<String> modNameFilters, Pageable pageable);
-
-
-    // Submitted accession query methods
-    @Query("submitted_accession:?0 AND assay_accession:?1")
-    List<ProteinIdentification> findBySubmittedAccessionAndAssayAccession(String submittedAccession, String assayAccession);
 
     // Queries with Projections
     @Query(value = "project_accession:?0", fields = { "accession" })

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepositoryFactory.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/service/repository/SolrProteinIdentificationRepositoryFactory.java
@@ -3,20 +3,15 @@ package uk.ac.ebi.pride.proteinidentificationindex.search.service.repository;
 import org.springframework.data.solr.core.SolrOperations;
 import org.springframework.data.solr.repository.support.SolrRepositoryFactory;
 
-/**
- * @author Jose A. Dianes
- * @version $Id$
- */
 public class SolrProteinIdentificationRepositoryFactory {
 
-    private SolrOperations solrOperations;
+  private SolrOperations solrOperations;
 
-    public SolrProteinIdentificationRepositoryFactory(SolrOperations solrOperations) {
-        this.solrOperations = solrOperations;
-    }
+  public SolrProteinIdentificationRepositoryFactory(SolrOperations solrOperations) {
+    this.solrOperations = solrOperations;
+  }
 
-    public SolrProteinIdentificationRepository create() {
-        return new SolrRepositoryFactory(this.solrOperations).getRepository(SolrProteinIdentificationRepository.class);
-    }
-
+  public SolrProteinIdentificationRepository create() {
+    return new SolrRepositoryFactory(this.solrOperations).getRepository(SolrProteinIdentificationRepository.class);
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/tools/ProteinIdentificationIndexBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/tools/ProteinIdentificationIndexBuilder.java
@@ -33,146 +33,124 @@ import java.util.Calendar;
 @Component
 public class ProteinIdentificationIndexBuilder {
 
-    private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationIndexBuilder.class.getName());
-    private static ErrorLogOutputStream errorLogOutputStream = new ErrorLogOutputStream(logger);
+  private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationIndexBuilder.class.getName());
+  private static ErrorLogOutputStream errorLogOutputStream = new ErrorLogOutputStream(logger);
 
-    private static final String PRIDE_MZ_TAB_FILE_EXTENSION = ".pride.mztab";
+  private static final String PRIDE_MZ_TAB_FILE_EXTENSION = ".pride.mztab";
 
-    private static final String COMPRESS_EXTENSION = "gz";
+  private static final String COMPRESS_EXTENSION = "gz";
 
-    private static final String INTERNAL_FOLDER_NAME = ProjectFileSource.INTERNAL.getFolderName();
-    private static final String GENERATED_FOLDER_NAME = ProjectFileSource.GENERATED.getFolderName();
+  private static final String INTERNAL_FOLDER_NAME = ProjectFileSource.INTERNAL.getFolderName();
+  private static final String GENERATED_FOLDER_NAME = ProjectFileSource.GENERATED.getFolderName();
 
-    @Autowired
-    private File submissionsDirectory;
+  @Autowired
+  private File submissionsDirectory;
 
-    @Autowired
-    private ProjectRepository projectRepository;
+  @Autowired
+  private ProjectRepository projectRepository;
 
-    @Autowired
-    private AssayRepository assayRepository;
+  @Autowired
+  private AssayRepository assayRepository;
 
-    @Autowired
-    private ProjectFileRepository projectFileRepository;
+  @Autowired
+  private ProjectFileRepository projectFileRepository;
 
-    @Autowired
-    private ProteinIdentificationSearchService proteinIdentificationSearchService;
+  @Autowired
+  private ProteinIdentificationSearchService proteinIdentificationSearchService;
 
-    @Autowired
-    private ProteinIdentificationIndexService proteinIdentificationIndexService;
+  @Autowired
+  private ProteinIdentificationIndexService proteinIdentificationIndexService;
 
-    @Autowired
-    private ProteinCatalogSearchService proteinCatalogSearchService;
+  @Autowired
+  private ProteinCatalogSearchService proteinCatalogSearchService;
 
-    @Autowired
-    private ProteinCatalogIndexService proteinCatalogIndexService;
+  @Autowired
+  private ProteinCatalogIndexService proteinCatalogIndexService;
 
-    @Autowired
-    private ProteinDetailsIndexer proteinCatalogDetailsIndexer;
+  @Autowired
+  private ProteinDetailsIndexer proteinCatalogDetailsIndexer;
 
 
-    public static void main(String[] args) {
+  public static void main(String[] args) {
+    ApplicationContext context = new ClassPathXmlApplicationContext("spring/app-context.xml");
+    ProteinIdentificationIndexBuilder proteinIdentificationIndexBuilder = context.getBean(ProteinIdentificationIndexBuilder.class);
+    indexProteinIdentifications(proteinIdentificationIndexBuilder);
+  }
 
-        ApplicationContext context = new ClassPathXmlApplicationContext("spring/app-context.xml");
-        ProteinIdentificationIndexBuilder proteinIdentificationIndexBuilder = context.getBean(ProteinIdentificationIndexBuilder.class);
-
-        indexProteinIdentifications(proteinIdentificationIndexBuilder);
-
-    }
-
-    public static void indexProteinIdentifications(ProteinIdentificationIndexBuilder proteinIdentificationIndexBuilder) {
-
-        // get all projects on repository
-        Iterable<? extends ProjectProvider> projects = proteinIdentificationIndexBuilder.projectRepository.findAll();
-
-        // reset index
-        proteinIdentificationIndexBuilder.proteinIdentificationIndexService.deleteAll();
-        logger.info("All Protein Identifications are now DELETED");
-
-        // create the indexer
-        ProjectProteinIdentificationsIndexer projectProteinIdentificationsIndexer =
-                new ProjectProteinIdentificationsIndexer(proteinIdentificationIndexBuilder.proteinIdentificationSearchService,
-                        proteinIdentificationIndexBuilder.proteinIdentificationIndexService,
-                        proteinIdentificationIndexBuilder.proteinCatalogSearchService,
-                        proteinIdentificationIndexBuilder.proteinCatalogIndexService,
-                        proteinIdentificationIndexBuilder.proteinCatalogDetailsIndexer);
-
-        // iterate through project to index psms
-        for (ProjectProvider project : projects) {
-
-            Iterable<? extends ProjectFileProvider> projectFiles = proteinIdentificationIndexBuilder.projectFileRepository.findAllByProjectId(project.getId());
-            for (ProjectFileProvider projectFile : projectFiles) {
-                //TODO: This will change when we have the internal file names in the database
-                //To avoid using submitted mztab we need to filter by generated ones first
-                if (ProjectFileSource.GENERATED.equals(projectFile.getFileSource())) {
-
-                    String fileName = projectFile.getFileName();
-
-                    if (fileName != null && fileName.contains(PRIDE_MZ_TAB_FILE_EXTENSION)) {
-
-                        //We should have only one assay per mzTab file
-                        String assayAccession = proteinIdentificationIndexBuilder.assayRepository.findOne(projectFile.getAssayId()).getAccession();
-
-                        String pathToMzTabFile = buildAbsoluteMzTabFilePath(
-                                proteinIdentificationIndexBuilder.submissionsDirectory.getAbsolutePath(),
-                                project,
-                                fileName
-                        );
-
-                        MZTabFileParser mzTabFileParser = null;
-                        try {
-                            logger.debug("Creating parser for MzTab file " + pathToMzTabFile);
-                            mzTabFileParser = new MZTabFileParser(new File(pathToMzTabFile), errorLogOutputStream);
-                            MZTabFile mzTabFile = mzTabFileParser.getMZTabFile();
-                            projectProteinIdentificationsIndexer.indexAllProteinIdentificationsForProjectAndAssay(project.getAccession(), assayAccession, mzTabFile);
-                        } catch (Exception e) {
-                            logger.error("Could not process MzTab file: " + pathToMzTabFile);
-                            logger.error("Cause: " + e.getCause());
-                        }
-
-                    }
-                }
+  public static void indexProteinIdentifications(ProteinIdentificationIndexBuilder proteinIdentificationIndexBuilder) {
+    Iterable<? extends ProjectProvider> projects = proteinIdentificationIndexBuilder.projectRepository.findAll();
+    proteinIdentificationIndexBuilder.proteinIdentificationIndexService.deleteAll();
+    logger.info("All Protein Identifications are now DELETED");
+    ProjectProteinIdentificationsIndexer projectProteinIdentificationsIndexer =
+        new ProjectProteinIdentificationsIndexer(proteinIdentificationIndexBuilder.proteinIdentificationSearchService,
+            proteinIdentificationIndexBuilder.proteinIdentificationIndexService,
+            proteinIdentificationIndexBuilder.proteinCatalogSearchService,
+            proteinIdentificationIndexBuilder.proteinCatalogIndexService,
+            proteinIdentificationIndexBuilder.proteinCatalogDetailsIndexer);
+    for (ProjectProvider project : projects) {
+      Iterable<? extends ProjectFileProvider> projectFiles = proteinIdentificationIndexBuilder.projectFileRepository.findAllByProjectId(project.getId());
+      for (ProjectFileProvider projectFile : projectFiles) {
+        if (ProjectFileSource.GENERATED.equals(projectFile.getFileSource())) {
+          String fileName = projectFile.getFileName();
+          if (fileName != null && fileName.contains(PRIDE_MZ_TAB_FILE_EXTENSION)) {
+            String assayAccession = proteinIdentificationIndexBuilder.assayRepository.findOne(projectFile.getAssayId()).getAccession();
+            String pathToMzTabFile = buildAbsoluteMzTabFilePath(
+                proteinIdentificationIndexBuilder.submissionsDirectory.getAbsolutePath(),
+                project,
+                fileName
+            );
+            MZTabFileParser mzTabFileParser;
+            try {
+              logger.debug("Creating parser for MzTab file " + pathToMzTabFile);
+              mzTabFileParser = new MZTabFileParser(new File(pathToMzTabFile), errorLogOutputStream);
+              MZTabFile mzTabFile = mzTabFileParser.getMZTabFile();
+              projectProteinIdentificationsIndexer.indexAllProteinIdentificationsForProjectAndAssay(project.getAccession(), assayAccession, mzTabFile);
+            } catch (Exception e) {
+              logger.error("Could not process MzTab file: " + pathToMzTabFile);
+              logger.error("Cause: " + e.getCause());
             }
+          }
         }
+      }
     }
+  }
 
-    //TODO: Move it to a pride-archive-utils
-    public static String buildAbsoluteMzTabFilePath(String prefix, ProjectProvider project, String fileName) {
-        if (project.isPublicProject()) {
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(project.getPublicationDate());
-            int month = calendar.get(Calendar.MONTH) + 1;
+  //TODO: Move it to a pride-archive-utils
+  public static String buildAbsoluteMzTabFilePath(String prefix, ProjectProvider project, String fileName) {
+    if (project.isPublicProject()) {
+      Calendar calendar = Calendar.getInstance();
+      calendar.setTime(project.getPublicationDate());
+      int month = calendar.get(Calendar.MONTH) + 1;
 
-            return prefix
-                    + File.separator + calendar.get(Calendar.YEAR)
-                    + File.separator + (month < 10 ? "0" : "") + month
-                    + File.separator + project.getAccession()
-                    + File.separator + INTERNAL_FOLDER_NAME
-                    + File.separator + translateFromGeneratedToInternalFolderFileName(fileName);
-        } else {
-            return prefix
-                    + File.separator + project.getAccession()
-                    + File.separator + INTERNAL_FOLDER_NAME
-                    + File.separator + translateFromGeneratedToInternalFolderFileName(fileName);
-        }
-
+      return prefix
+          + File.separator + calendar.get(Calendar.YEAR)
+          + File.separator + (month < 10 ? "0" : "") + month
+          + File.separator + project.getAccession()
+          + File.separator + INTERNAL_FOLDER_NAME
+          + File.separator + translateFromGeneratedToInternalFolderFileName(fileName);
+    } else {
+      return prefix
+          + File.separator + project.getAccession()
+          + File.separator + INTERNAL_FOLDER_NAME
+          + File.separator + translateFromGeneratedToInternalFolderFileName(fileName);
     }
+  }
 
-    //TODO: Move it to a pride-archive-utils
-    /**
-     * In the generated folder(the which one we are taking the file names) the files are gzip, so we need to remove
-     * the extension to have the name in the internal folder (the one that we want)
-     *
-     * @param fileName mztab file name in generated folder
-     * @return mztab file name in internal folder
-     */
-    private static String translateFromGeneratedToInternalFolderFileName(String fileName) {
+  //TODO: Move it to a pride-archive-utils
+  /**
+   * In the generated folder(the which one we are taking the file names) the files are gzip, so we need to remove
+   * the extension to have the name in the internal folder (the one that we want)
+   *
+   * @param fileName mztab file name in generated folder
+   * @return mztab file name in internal folder
+   */
+  private static String translateFromGeneratedToInternalFolderFileName(String fileName) {
 
-        if (fileName != null) {
-            if (fileName.endsWith(COMPRESS_EXTENSION)) {
-                fileName = fileName.substring(0, fileName.lastIndexOf("."));
-            }
-        }
-        return fileName;
+    if (fileName != null) {
+      if (fileName.endsWith(COMPRESS_EXTENSION)) {
+        fileName = fileName.substring(0, fileName.lastIndexOf("."));
+      }
     }
+    return fileName;
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinDetailUtils.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinDetailUtils.java
@@ -9,24 +9,21 @@ import java.util.List;
  */
 public class ProteinDetailUtils {
 
-    public static final String NAME = "NAME####";
+  public static final String NAME = "NAME####";
 
-    public static String extractInformationByType(List<String> description, String type){
-
-        String info = null;
-
-        if(description != null){
-            for (String s : description){
-                if(s.startsWith(type)){
-                    info = s.split(type)[1];
-                }
-            }
+  public static String extractInformationByType(List<String> description, String type){
+    String info = null;
+    if(description != null){
+      for (String s : description){
+        if(s.startsWith(type)){
+          info = s.split(type)[1];
         }
-
-        return info;
+      }
     }
+    return info;
+  }
 
-    public static String getNameFromDescription(List<String> description){
-        return extractInformationByType(description, NAME);
-    }
+  public static String getNameFromDescription(List<String> description){
+    return extractInformationByType(description, NAME);
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationIdBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationIdBuilder.java
@@ -6,26 +6,26 @@ package uk.ac.ebi.pride.proteinidentificationindex.search.util;
  */
 public class ProteinIdentificationIdBuilder {
 
-    public static final String SEPARATOR = "_%_%_";
+  public static final String SEPARATOR = "_%_%_";
 
-    public static String getId(String proteinAccession, String projectAccession, String assayAccession) {
-        return proteinAccession + SEPARATOR + projectAccession + SEPARATOR + assayAccession;
-    }
+  public static String getId(String proteinAccession, String projectAccession, String assayAccession) {
+    return proteinAccession + SEPARATOR + projectAccession + SEPARATOR + assayAccession;
+  }
 
-    public static String getProteinAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[0];
-    }
+  public static String getProteinAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[0];
+  }
 
-    public static String getProjectAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[1];
-    }
+  public static String getProjectAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[1];
+  }
 
-    public static String getAssayAccession(String id) {
-        String [] tokens = id.split(SEPARATOR);
-        return tokens[2];
-    }
+  public static String getAssayAccession(String id) {
+    String [] tokens = id.split(SEPARATOR);
+    return tokens[2];
+  }
 
 
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationMzTabBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationMzTabBuilder.java
@@ -10,94 +10,60 @@ import uk.ac.ebi.pride.jmztab.model.Protein;
 import uk.ac.ebi.pride.proteinidentificationindex.search.model.ProteinIdentification;
 import uk.ac.ebi.pride.tools.utils.AccessionResolver;
 
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.TreeSet;
+import java.util.*;
 
-/**
- * @author Jose A. Dianes
- * @version $Id$
- */
 public class ProteinIdentificationMzTabBuilder {
 
-    private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationMzTabBuilder.class.getName());
+  private static Logger logger = LoggerFactory.getLogger(ProteinIdentificationMzTabBuilder.class.getName());
 
-    public static String OPTIONAL_SEQUENCE_COLUMN   = "protein_sequence";
+  public static String OPTIONAL_SEQUENCE_COLUMN   = "protein_sequence";
 
-    public static List<ProteinIdentification> readProteinIdentificationsFromMzTabFile(String projectAccession, String assayAccession, MZTabFile tabFile) {
-
-        List<ProteinIdentification> res = new LinkedList<ProteinIdentification>();
-        String sequence;
-
-        if (tabFile != null) {
-            // get proteins
-            Collection<Protein> mzTabProteins = tabFile.getProteins();
-            for (Protein mzTabProtein: mzTabProteins) {
-                ProteinIdentification proteinIdentification = new ProteinIdentification();
-                proteinIdentification.setId(ProteinIdentificationIdBuilder.getId(mzTabProtein.getAccession(), projectAccession, assayAccession));
-                proteinIdentification.setOtherMappings(new TreeSet<String>());
-                proteinIdentification.setSubmittedAccession(mzTabProtein.getAccession());
-                proteinIdentification.setAssayAccession(assayAccession);
-                proteinIdentification.setProjectAccession(projectAccession);
-                proteinIdentification.setAmbiguityGroupSubmittedAccessions(new LinkedList<String>());
-
-                //check if we have submitted sequence in mzTab and try to retrive it
-                if((sequence = mzTabProtein.getOptionColumnValue(OPTIONAL_SEQUENCE_COLUMN))!= null){
-                    if(!sequence.isEmpty()){
-                        proteinIdentification.setSubmittedSequence(sequence);
-                        logger.debug("Retrieved submitted sequence");
-                    }
-                }
-
-                if (mzTabProtein.getAmbiguityMembers()!=null && mzTabProtein.getAmbiguityMembers().size()>0 && !mzTabProtein.getAmbiguityMembers().get(0).equals("null")) {
-                    proteinIdentification.getAmbiguityGroupSubmittedAccessions().addAll(mzTabProtein.getAmbiguityMembers());
-                }
-                proteinIdentification.setModifications(new LinkedList<ModificationProvider>());
-                if (mzTabProtein.getModifications()!=null && mzTabProtein.getModifications().size()>0 && !mzTabProtein.getModifications().get(0).equals("null")) {
-                    for (Modification mod: mzTabProtein.getModifications())
-                    proteinIdentification.addModification(ModificationHelper.convertToModificationProvider(mod));
-                }
-                // try to add a resolved accession to reference the catalog
-                try {
-                    String correctedAccession = getCorrectedAccession(mzTabProtein.getAccession(), mzTabProtein.getDatabase());
-                    proteinIdentification.setAccession(correctedAccession);
-                } catch (Exception e) {
-                    logger.error("Cannot correct protein accession " + mzTabProtein.getAccession() + " with DB " + mzTabProtein.getDatabase());
-                    logger.error("Original accession will be used");
-                    logger.error("Cause:" + e.getCause());
-                    proteinIdentification.setAccession(mzTabProtein.getAccession());
-                }
-                // add to final result
-                res.add(proteinIdentification);
-
-            }
-
-            logger.debug("Found " + res.size() + " protein identifications for Assay " + assayAccession + " in file.");
-        } else {
-            logger.error("Passed null mzTab file to protein identifications reader");
+  public static List<ProteinIdentification> readProteinIdentificationsFromMzTabFile(String projectAccession, String assayAccession, MZTabFile tabFile) {
+    List<ProteinIdentification> result = new LinkedList<>();
+    String sequence;
+    if (tabFile != null) {
+      Collection<Protein> mzTabProteins = tabFile.getProteins();
+      for (Protein mzTabProtein: mzTabProteins) {
+        ProteinIdentification proteinIdentification = new ProteinIdentification();
+        proteinIdentification.setId(ProteinIdentificationIdBuilder.getId(mzTabProtein.getAccession(), projectAccession, assayAccession));
+        proteinIdentification.setAssayAccession(assayAccession);
+        proteinIdentification.setProjectAccession(projectAccession);
+        proteinIdentification.setModificationNames(new ArrayList<>());
+        if (mzTabProtein.getModifications()!=null && mzTabProtein.getModifications().size()>0 && !mzTabProtein.getModifications().get(0).toString().equalsIgnoreCase("null")) {
+          for (Modification mod: mzTabProtein.getModifications())
+            proteinIdentification.addModificationName(ModificationHelper.convertToModificationProvider(mod));
         }
-
-        return res;
-    }
-
-    private static String getCorrectedAccession(String accession, String database) {
-
-        try {
-            AccessionResolver accessionResolver = new AccessionResolver(accession, null, database); // we don't have versions
-            String fixedAccession = accessionResolver.getAccession();
-
-            if (fixedAccession == null || "".equals(fixedAccession)) {
-                logger.debug("No proper fix found for accession " + accession + ". Obtained: <" + fixedAccession +">. Original accession will be used.");
-                return accession;
-            } else {
-                logger.debug("Original accession " + accession + " fixed to " + fixedAccession);
-                return fixedAccession;
-            }
+        try {  // try to add a resolved accession to reference the catalog
+          String correctedAccession = getCorrectedAccession(mzTabProtein.getAccession(), mzTabProtein.getDatabase());
+          proteinIdentification.setAccession(correctedAccession);
         } catch (Exception e) {
-            logger.error("There were problems getting corrected accession for " + accession +". Original accession will be used.");
-            return accession;
+          logger.error("Cannot correct protein accession " + mzTabProtein.getAccession() + " with DB " + mzTabProtein.getDatabase());
+          logger.error("Original accession will be used", e);
+          proteinIdentification.setAccession(mzTabProtein.getAccession());
         }
+        result.add(proteinIdentification);
+      }
+      logger.debug("Found " + result.size() + " protein identifications for Assay " + assayAccession + " in file.");
+    } else {
+      logger.error("Passed null mzTab file to protein identifications reader");
     }
+    return result;
+  }
 
+  private static String getCorrectedAccession(String accession, String database) {
+    try {
+      AccessionResolver accessionResolver = new AccessionResolver(accession, null, database); // we don't have versions
+      String fixedAccession = accessionResolver.getAccession();
+      if (fixedAccession == null || "".equals(fixedAccession)) {
+        logger.debug("No proper fix found for accession " + accession + ". Obtained: <" + fixedAccession +">. Original accession will be used.");
+        return accession;
+      } else {
+        logger.debug("Original accession " + accession + " fixed to " + fixedAccession);
+        return fixedAccession;
+      }
+    } catch (Exception e) {
+      logger.error("There were problems getting corrected accession for " + accession +". Original accession will be used.");
+      return accession;
+    }
+  }
 }

--- a/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationMzTabBuilder.java
+++ b/src/main/java/uk/ac/ebi/pride/proteinidentificationindex/search/util/ProteinIdentificationMzTabBuilder.java
@@ -28,7 +28,7 @@ public class ProteinIdentificationMzTabBuilder {
         proteinIdentification.setId(ProteinIdentificationIdBuilder.getId(mzTabProtein.getAccession(), projectAccession, assayAccession));
         proteinIdentification.setAssayAccession(assayAccession);
         proteinIdentification.setProjectAccession(projectAccession);
-        proteinIdentification.setModificationNames(new ArrayList<>());
+        proteinIdentification.setModificationNames(new ArrayList<ModificationProvider>());
         if (mzTabProtein.getModifications()!=null && mzTabProtein.getModifications().size()>0 && !mzTabProtein.getModifications().get(0).toString().equalsIgnoreCase("null")) {
           for (Modification mod: mzTabProtein.getModifications())
             proteinIdentification.addModificationName(ModificationHelper.convertToModificationProvider(mod));

--- a/src/main/resources/solr/conf/schema.xml
+++ b/src/main/resources/solr/conf/schema.xml
@@ -99,18 +99,8 @@
 
         <!-- identifier for each document: the protein submittedAccession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="submitted_accession" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="accession" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="uniprot_mapping" type="text_ws" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="ensembl_mapping" type="text_ws" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="other_mappings" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="submitted_sequence" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="inferred_sequence" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="description" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="ambiguity_group" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="modifications" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="mod_names" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_accessions" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false" />
         <field name="assay_accession" type="string" indexed="true" stored="true" required="false" multiValued="false" />
 

--- a/src/test/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationIndexerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationIndexerTest.java
@@ -29,76 +29,78 @@ import java.util.List;
 
 public class ProjectProteinIdentificationIndexerTest extends SolrTestCaseJ4 {
 
-    private static Logger logger = LoggerFactory.getLogger(ProjectProteinIdentificationIndexerTest.class.getName());
 
-    private static final String TEST_SUBMITTED_SEQ = "MSSEEVVVAVEEQEIPDVIERLMSSEEVVVAVEEQEIPDVIERLMSSEEVVVAVEEQEIPDVIERL";
-    private static final String TEST_ID = "TEST_ID";
-    private static final String TEST_SUBMITTED_AC = "D0NNB3";
+  private static Logger logger = LoggerFactory.getLogger(ProjectProteinIdentificationIndexerTest.class.getName());
 
-    private static final String TEST_PROTEIN_ACCESSION = "D0NNB3";
-    private static SolrServer server;
+  private static final String TEST_PROJ_ACCESSION = "PXT000001";
+  private static final String TEST_ASSAY_ACCESSION = "123456";
+  private static final String TEST_ID = "TEST_ID";
 
-    private static SolrProteinIdentificationRepositoryFactory solrProteinIdentificationRepositoryFactory;
+  private static final String TEST_PROTEIN_ACCESSION = "D0NNB3";
+  private static SolrServer server;
 
-    public static final long ZERO_DOCS = 0L;
+  private static SolrProteinIdentificationRepositoryFactory solrProteinIdentificationRepositoryFactory;
 
-    @BeforeClass
-    public static void initialise() throws Exception {
-        initCore("src/test/resources/solr/protein-identification-index/conf/solrconfig.xml",
-                "src/test/resources/solr/protein-identification-index/conf/schema.xml",
-                "src/test/resources/solr",
-                "protein-identification-index");
-    }
+  public static final long ZERO_DOCS = 0L;
 
-    @AfterClass
-    public static void cleanUp() throws Exception {
-        deleteCore();
-    }
+  @BeforeClass
+  public static void initialise() throws Exception {
+    initCore("src/test/resources/solr/protein-identification-index/conf/solrconfig.xml",
+        "src/test/resources/solr/protein-identification-index/conf/schema.xml",
+        "src/test/resources/solr",
+        "protein-identification-index");
+  }
 
-
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-        server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
-        server.deleteByQuery("*:*");
-        solrProteinIdentificationRepositoryFactory = new SolrProteinIdentificationRepositoryFactory(new SolrTemplate(server));
-    }
-
-    @Test
-    public void testThatNoResultsAreReturned() throws SolrServerException {
-        SolrParams params = new SolrQuery("text that is not found");
-        QueryResponse response = server.query(params);
-        assertEquals(ZERO_DOCS, response.getResults().getNumFound());
-    }
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    deleteCore();
+  }
 
 
-    @Test
-    public void testAddProtein() {
-        addD0NNb3();
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
+    server.deleteByQuery("*:*");
+    solrProteinIdentificationRepositoryFactory = new SolrProteinIdentificationRepositoryFactory(new SolrTemplate(server));
+  }
 
-        ProteinIdentificationSearchService proteinIdentificationSearchService = new ProteinIdentificationSearchService(solrProteinIdentificationRepositoryFactory.create());
-        ProteinIdentificationIndexService proteinIdentificationIndexService = new ProteinIdentificationIndexService(server, solrProteinIdentificationRepositoryFactory.create());
+  @Test
+  public void testThatNoResultsAreReturned() throws SolrServerException {
+    SolrParams params = new SolrQuery("text that is not found");
+    QueryResponse response = server.query(params);
+    assertEquals(ZERO_DOCS, response.getResults().getNumFound());
+  }
 
-        List<ProteinIdentification> proteins = proteinIdentificationSearchService.findByAccession(TEST_PROTEIN_ACCESSION);
+  @Test
+  public void testAddProtein() {
+    addD0NNb3();
+    ProteinIdentificationSearchService proteinIdentificationSearchService = new ProteinIdentificationSearchService(solrProteinIdentificationRepositoryFactory.create());
+    ProteinIdentificationIndexService proteinIdentificationIndexService = new ProteinIdentificationIndexService(server, solrProteinIdentificationRepositoryFactory.create());
+    List<ProteinIdentification> proteins = proteinIdentificationSearchService.findByAccession(TEST_PROTEIN_ACCESSION);
+    proteinIdentificationIndexService.save(proteins.get(0));
+    proteins = proteinIdentificationSearchService.findByAccession(TEST_PROTEIN_ACCESSION);
+    assertNotNull(proteins);
+    assertNotNull(proteins.get(0));
+    assertEquals(proteins.get(0).getId(), TEST_ID);
+    assertEquals(proteins.get(0).getAccession(), TEST_PROTEIN_ACCESSION);
+    Long count = proteinIdentificationSearchService.countByAssayAccession(TEST_ASSAY_ACCESSION);
+    assertEquals(count.longValue(), 1L);
+    count = proteinIdentificationSearchService.countByProjectAccession(TEST_PROJ_ACCESSION);
+    assertEquals(count.longValue(), 1L);
+    count = proteinIdentificationSearchService.countByProjectAccessionAndAccession(TEST_PROJ_ACCESSION, TEST_PROTEIN_ACCESSION);
+    assertEquals(count.longValue(), 1L);
+  }
 
-        proteinIdentificationIndexService.save(proteins.get(0));
 
-        proteins = proteinIdentificationSearchService.findByAccession(TEST_PROTEIN_ACCESSION);
-
-        assertNotNull(proteins);
-        assertNotNull(proteins.get(0));
-        assertEquals(proteins.get(0).getId(), TEST_ID);
-        assertEquals(proteins.get(0).getAccession(), TEST_PROTEIN_ACCESSION);
-
-    }
-
-
-    private void addD0NNb3() {
-        ProteinIdentificationIndexService proteinIdentificationIndexService = new ProteinIdentificationIndexService(server, solrProteinIdentificationRepositoryFactory.create());
-        ProteinIdentification proteinIdentification = new ProteinIdentification();
-        proteinIdentification.setId(TEST_ID);
-        proteinIdentification.setAccession(TEST_PROTEIN_ACCESSION);
-        proteinIdentificationIndexService.save(proteinIdentification);
-    }
+  private void addD0NNb3() {
+    ProteinIdentificationIndexService proteinIdentificationIndexService = new ProteinIdentificationIndexService(server, solrProteinIdentificationRepositoryFactory.create());
+    ProteinIdentification proteinIdentification = new ProteinIdentification();
+    proteinIdentification.setId(TEST_ID);
+    proteinIdentification.setProjectAccession(TEST_PROJ_ACCESSION);
+    proteinIdentification.setAssayAccession(TEST_ASSAY_ACCESSION);
+    proteinIdentification.setAccession(TEST_PROTEIN_ACCESSION);
+    proteinIdentificationIndexService.save(proteinIdentification);
+  }
 }

--- a/src/test/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationIndexerTest.java
+++ b/src/test/java/uk/ac/ebi/pride/proteinidentificationindex/search/indexer/ProjectProteinIdentificationIndexerTest.java
@@ -36,8 +36,6 @@ public class ProjectProteinIdentificationIndexerTest extends SolrTestCaseJ4 {
     private static final String TEST_SUBMITTED_AC = "D0NNB3";
 
     private static final String TEST_PROTEIN_ACCESSION = "D0NNB3";
-    private static final String TEST_PROTEIN_NAME_FIELD = "NAME####Putative uncharacterized protein";
-    private static final String TEST_PROTEIN_SEQ_STARTS_WITH = "MSSEEVVVAVEEQEIPDVIERL";
     private static SolrServer server;
 
     private static SolrProteinIdentificationRepositoryFactory solrProteinIdentificationRepositoryFactory;
@@ -64,7 +62,6 @@ public class ProjectProteinIdentificationIndexerTest extends SolrTestCaseJ4 {
         super.setUp();
         server = new EmbeddedSolrServer(h.getCoreContainer(), h.getCore().getName());
         server.deleteByQuery("*:*");
-
         solrProteinIdentificationRepositoryFactory = new SolrProteinIdentificationRepositoryFactory(new SolrTemplate(server));
     }
 
@@ -93,8 +90,6 @@ public class ProjectProteinIdentificationIndexerTest extends SolrTestCaseJ4 {
         assertNotNull(proteins.get(0));
         assertEquals(proteins.get(0).getId(), TEST_ID);
         assertEquals(proteins.get(0).getAccession(), TEST_PROTEIN_ACCESSION);
-        assertEquals(proteins.get(0).getSubmittedAccession(), TEST_SUBMITTED_AC);
-        assertTrue(proteins.get(0).getSubmittedSequence().equals(TEST_SUBMITTED_SEQ));
 
     }
 
@@ -104,10 +99,6 @@ public class ProjectProteinIdentificationIndexerTest extends SolrTestCaseJ4 {
         ProteinIdentification proteinIdentification = new ProteinIdentification();
         proteinIdentification.setId(TEST_ID);
         proteinIdentification.setAccession(TEST_PROTEIN_ACCESSION);
-        proteinIdentification.setSubmittedAccession(TEST_SUBMITTED_AC);
-        proteinIdentification.setSubmittedSequence(TEST_SUBMITTED_SEQ);
         proteinIdentificationIndexService.save(proteinIdentification);
     }
-
-
 }

--- a/src/test/resources/solr/protein-identification-index/conf/schema.xml
+++ b/src/test/resources/solr/protein-identification-index/conf/schema.xml
@@ -99,18 +99,8 @@
 
         <!-- identifier for each document: the protein submittedAccession -->
         <field name="id" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="submitted_accession" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
         <field name="accession" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
-        <field name="uniprot_mapping" type="text_ws" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="ensembl_mapping" type="text_ws" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="other_mappings" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="submitted_sequence" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="inferred_sequence" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
-        <field name="description" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="ambiguity_group" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="modifications" type="text_ws" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="mod_names" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
-        <field name="mod_accessions" type="string" indexed="true" stored="true" required="false" multiValued="true"/>
         <field name="project_accession" type="string" indexed="true" stored="true" required="false" multiValued="false" />
         <field name="assay_accession" type="string" indexed="true" stored="true" required="false" multiValued="false" />
 


### PR DESCRIPTION
Reduces the number of fields Solr indexes, so Solr is used more as an index. Detailed information about protein IDs should be queried in conjunction with the new https://github.com/PRIDE-Archive/mongo-protein-identification-index-search